### PR TITLE
Dapper.Contrib - Overload for Update with expression for selecting columns to update

### DIFF
--- a/Dapper.Contrib/Readme.md
+++ b/Dapper.Contrib/Readme.md
@@ -14,7 +14,9 @@ IEnumerable<T> GetAll<T>();
 int Insert<T>(T obj);
 int Insert<T>(Enumerable<T> list);
 bool Update<T>(T obj);
+bool Update<T>(T obj, Expression<Func<T, object>> columnsToUpdate);
 bool Update<T>(Enumerable<T> list);
+bool Update<T>(Enumerable<T> list, Expression<Func<Enumerable<T>, object>> columnsToUpdate);
 bool Delete<T>(T obj);
 bool Delete<T>(Enumerable<T> list);
 bool DeleteAll<T>();
@@ -88,19 +90,19 @@ Update one specific entity
 connection.Update(new Car() { Id = 1, Name = "Saab" });
 ```
 
-or with column selection
+or with selected columns to update
 
 ```csharp
 connection.Update(new Car() { Id = 1, Name = "Saab" }, t=> new { t=> t.Name, t.Age });
 ```
 
-or update a list of entities.
+or update a list of entities
 
 ```csharp
 connection.Update(cars);
 ```
 
-with column selection
+with selected columns to update.
 
 ```csharp
 connection.Update(cars, t=> new { t[0].Name });

--- a/Dapper.Contrib/Readme.md
+++ b/Dapper.Contrib/Readme.md
@@ -100,6 +100,12 @@ or update a list of entities.
 connection.Update(cars);
 ```
 
+with column selection
+
+```csharp
+connection.Update(cars, t=> new { t[0].Name });
+```
+
 `Delete` methods
 -------
 Delete an entity by the specified `[Key]` property

--- a/Dapper.Contrib/Readme.md
+++ b/Dapper.Contrib/Readme.md
@@ -88,6 +88,12 @@ Update one specific entity
 connection.Update(new Car() { Id = 1, Name = "Saab" });
 ```
 
+or with column selection
+
+```csharp
+connection.Update(new Car() { Id = 1, Name = "Saab" }, t=> new { t=> t.Name, t.Age });
+```
+
 or update a list of entities.
 
 ```csharp

--- a/Dapper.Contrib/SqlMapperExtensions.Async.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.Async.cs
@@ -248,7 +248,7 @@ namespace Dapper.Contrib.Extensions
         /// <returns>true if updated, false if not found or not modified (tracked entities)</returns>
         /// <example>
         /// <code>
-        ///     Update&lt;Poco&gt;(conn, poco, t=> new { t.Prop1, t.Prop2 } );
+        ///     Update&lt;Poco&gt;(poco, t=> new { t.Prop1, t.Prop2 } );
         /// </code>
         /// </example>
         public static async Task<bool> UpdateAsync<T>(this IDbConnection connection, T entityToUpdate, Expression<Func<T, object>> fieldsToUpdate, IDbTransaction transaction = null, int? commandTimeout = null) where T : class

--- a/Dapper.Tests/TestBase.cs
+++ b/Dapper.Tests/TestBase.cs
@@ -39,6 +39,7 @@ namespace Dapper.Tests
         public SqlConnection GetClosedConnection()
         {
             var conn = new SqlConnection(ConnectionString);
+            
             if (conn.State != ConnectionState.Closed) throw new InvalidOperationException("should be closed!");
             return conn;
         }


### PR DESCRIPTION
Hi,

I've added new overloads for Update with expression for selecting columns to update. I don't know if it fits the idea of Dapper.Contrib. 

For example

`connection.Update(new Car() { Id = 1, Name = "Saab" }, t=> new { t=> t.Name, t.Age });`

it's a bit clumsy for arrays and lists, but I can live with it. I can't remember solution that has simpler implementation without breaking the idea of other update methods.

`connection.Update(cars, t=> new { t[0].Name });`

Appreciate comments and review.

Cheers