### PR TITLE
Added From and DerivedFrom handlers

### DIFF
--- a/Dapper.SqlBuilder/SqlBuilder.cs
+++ b/Dapper.SqlBuilder/SqlBuilder.cs
@@ -149,5 +149,14 @@ namespace Dapper
 
         public SqlBuilder Having(string sql, dynamic parameters = null) =>
             AddClause("having", sql, parameters, "\nAND ", "HAVING ", "\n", false);
+
+        public SqlBuilder From(string sql) =>
+            AddClause("from", sql, null, "*", "FROM ", "", false);
+
+        public SqlBuilder DerivedFrom(Template sqlTemplate, string alias) =>
+            DerivedFrom(sqlTemplate.RawSql, alias);
+
+        public SqlBuilder DerivedFrom(string sql, string alias) =>
+            AddClause("derived", sql, null, "*", "FROM (", $") as {alias}", false);
     }
 }


### PR DESCRIPTION
What's up SO team?!

Have been using dapper for some time, only recently began using the SqlBuilder. In my travels I encountered several circumstances where having a ".From()" and ".DerivedFrom()" handler was quite useful.

Use case as follows:

```c#
var listBuilder = new SqlBuilder();
var pageBuilder = new SqlBuilder();

var list = listBuilder.AddTemplate("select /**select**/ /**from**/ /**where**/");
listBuilder.Select("*, row_number() over (order by CreatedAtUtc desc) as rn")
			.From("dbo.TableNeedingPaging")
			.Where("Deleted = 0");

var page = pageBuilder.AddTemplate("select /**select**/ /**derived**/ /**where**/");
pageBuilder.Select("*")
			.DerivedFrom(list, "tbl")
			.Where("rn between 0 and 20");

Console.WriteLine(page.RawSql);
```

Which ouputs:
```sql
select *
 FROM (select *, row_number() over (order by CreatedAtUtc desc) as rn
 FROM dbo.TableNeedingPaging WHERE Deleted = 0
) as tbl WHERE rn between 0 and 20
```