### PR TITLE
[Delete] & [Update] methods fixed for generic entities.

### DIFF
--- a/Dapper.Contrib/SqlMapperExtensions.Async.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.Async.cs
@@ -219,7 +219,7 @@ namespace Dapper.Contrib.Extensions
             {
                 type = type.GetElementType();
             }
-            else if (type.IsGenericType())
+            else if (type.IsGenericType() && SqlMapper.IsMultiValue(entityToUpdate))
             {
                 type = type.GetGenericArguments()[0];
             }
@@ -280,7 +280,7 @@ namespace Dapper.Contrib.Extensions
             {
                 type = type.GetElementType();
             }
-            else if (type.IsGenericType())
+            else if (type.IsGenericType() && SqlMapper.IsMultiValue(entityToDelete))
             {
                 type = type.GetGenericArguments()[0];
             }

--- a/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.cs
@@ -413,7 +413,7 @@ namespace Dapper.Contrib.Extensions
             {
                 type = type.GetElementType();
             }
-            else if (type.IsGenericType())
+            else if (type.IsGenericType() && SqlMapper.IsMultiValue(entityToUpdate))
             {
                 type = type.GetGenericArguments()[0];
             }
@@ -474,7 +474,7 @@ namespace Dapper.Contrib.Extensions
             {
                 type = type.GetElementType();
             }
-            else if (type.IsGenericType())
+            else if (type.IsGenericType() && SqlMapper.IsMultiValue(entityToDelete))
             {
                 type = type.GetGenericArguments()[0];
             }

--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -503,13 +503,23 @@ namespace Dapper
         public static T ExecuteScalar<T>(this IDbConnection cnn, CommandDefinition command) =>
             ExecuteScalarImpl<T>(cnn, ref command);
 
+        /// <summary>
+        /// Check if an object is a multivalue object.
+        /// </summary>
+        /// <param name="value">The object is being checked.</param>
+        /// <returns>[true] if the object is a multivalue object.</returns>
+        public static bool IsMultiValue(object value)
+        {
+            return (value is IEnumerable
+                    && !(value is string
+                      || value is IEnumerable<KeyValuePair<string, object>>
+                      || value is IDynamicParameters)
+                );
+        }
+
         private static IEnumerable GetMultiExec(object param)
         {
-            return (param is IEnumerable
-                    && !(param is string
-                      || param is IEnumerable<KeyValuePair<string, object>>
-                      || param is IDynamicParameters)
-                ) ? (IEnumerable)param : null;
+            return IsMultiValue(param) ? (IEnumerable)param : null;
         }
 
         private static int ExecuteImpl(this IDbConnection cnn, ref CommandDefinition command)


### PR DESCRIPTION
`Delete` & `Update` methods threw the exception _"Entity must have at least one [Key] or [ExplicitKey] property"_ for a generic entity like this:
```
    public class GenericUser<TKey>
         where TKey : IEquatable<TKey>
    {
        [Key]
        public TKey Id { get; set; }
        public string Name { get; set; }
        public int Age { get; set; }
    }
```
I'm not sure that it's a good idea to expose a new method from the `SqlMapper`, probably it needs to be refactored: https://github.com/StackExchange/Dapper/pull/1004/files#diff-48000d1adc3fd2af62b908b6d189dc59R511

P.S.
I didn't check the `Insert(Async)` methods and others from the `Dapper.Contrib`, there is a chance they have the same issue too.