### PR TITLE
fix inconsistent Contrib column name formatting in postgres and test

### DIFF
--- a/Dapper.Contrib/SqlMapperExtensions.Async.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.Async.cs
@@ -25,18 +25,12 @@ namespace Dapper.Contrib.Extensions
         public static async Task<T> GetAsync<T>(this IDbConnection connection, dynamic id, IDbTransaction transaction = null, int? commandTimeout = null) where T : class
         {
             var type = typeof(T);
-            var adapter = GetFormatter(connection);
-
             if (!GetQueries.TryGetValue(type.TypeHandle, out string sql))
             {
                 var key = GetSingleKey<T>(nameof(GetAsync));
                 var name = GetTableName(type);
 
-                var sb = new StringBuilder("select * from ");
-                sb.Append(name);
-                sb.Append(" where ");
-                adapter.AppendColumnNameEqualsValue(sb, key.Name);
-                sql = sb.ToString();
+                sql = $"SELECT * FROM {name} WHERE {key.Name} = @id";
                 GetQueries[type.TypeHandle] = sql;
             }
 
@@ -499,7 +493,7 @@ public partial class PostgresAdapter
                 if (!first)
                     sb.Append(", ");
                 first = false;
-                AppendColumnName(sb, property.Name);
+                sb.Append(property.Name);
             }
         }
 
@@ -509,7 +503,7 @@ public partial class PostgresAdapter
         var id = 0;
         foreach (var p in propertyInfos)
         {
-            var value = ((IDictionary<string, object>)results.First())[p.Name];
+            var value = ((IDictionary<string, object>)results.First())[p.Name.ToLower()];
             p.SetValue(entityToInsert, Convert.ChangeType(value, p.PropertyType), null);
             if (id == 0)
                 id = Convert.ToInt32(value);

--- a/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.cs
@@ -175,19 +175,13 @@ namespace Dapper.Contrib.Extensions
         public static T Get<T>(this IDbConnection connection, dynamic id, IDbTransaction transaction = null, int? commandTimeout = null) where T : class
         {
             var type = typeof(T);
-            var adapter = GetFormatter(connection);
 
             if (!GetQueries.TryGetValue(type.TypeHandle, out string sql))
             {
                 var key = GetSingleKey<T>(nameof(Get));
                 var name = GetTableName(type);
 
-                var sb = new StringBuilder("select * from ");
-                sb.Append(name);
-                sb.Append(" where ");
-                adapter.AppendColumnName(sb, key.Name);
-                sb.Append(" = @id;");
-                sql = sb.ToString();
+                sql = $"select * from {name} where {key.Name} = @id";
                 GetQueries[type.TypeHandle] = sql;
             }
 
@@ -1017,7 +1011,7 @@ public partial class PostgresAdapter : ISqlAdapter
                 if (!first)
                     sb.Append(", ");
                 first = false;
-                AppendColumnName(sb, property.Name);
+                sb.Append(property.Name);
             }
         }
 
@@ -1027,7 +1021,7 @@ public partial class PostgresAdapter : ISqlAdapter
         var id = 0;
         foreach (var p in propertyInfos)
         {
-            var value = ((IDictionary<string, object>)results[0])[p.Name];
+            var value = ((IDictionary<string, object>)results[0])[p.Name.ToLower()];
             p.SetValue(entityToInsert, Convert.ChangeType(value, p.PropertyType), null);
             if (id == 0)
                 id = Convert.ToInt32(value);

--- a/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.cs
@@ -175,13 +175,19 @@ namespace Dapper.Contrib.Extensions
         public static T Get<T>(this IDbConnection connection, dynamic id, IDbTransaction transaction = null, int? commandTimeout = null) where T : class
         {
             var type = typeof(T);
+            var adapter = GetFormatter(connection);
 
             if (!GetQueries.TryGetValue(type.TypeHandle, out string sql))
             {
                 var key = GetSingleKey<T>(nameof(Get));
                 var name = GetTableName(type);
 
-                sql = $"select * from {name} where {key.Name} = @id";
+                var sb = new StringBuilder("select * from ");
+                sb.Append(name);
+                sb.Append(" where ");
+                adapter.AppendColumnName(sb, key.Name);
+                sb.Append(" = @id;");
+                sql = sb.ToString();
                 GetQueries[type.TypeHandle] = sql;
             }
 
@@ -1011,7 +1017,7 @@ public partial class PostgresAdapter : ISqlAdapter
                 if (!first)
                     sb.Append(", ");
                 first = false;
-                sb.Append(property.Name);
+                AppendColumnName(sb, property.Name);
             }
         }
 
@@ -1021,8 +1027,8 @@ public partial class PostgresAdapter : ISqlAdapter
         var id = 0;
         foreach (var p in propertyInfos)
         {
-            var value = ((IDictionary<string, object>)results[0])[p.Name.ToLower()];
-            p.SetValue(entityToInsert, value, null);
+            var value = ((IDictionary<string, object>)results[0])[p.Name];
+            p.SetValue(entityToInsert, Convert.ChangeType(value, p.PropertyType), null);
             if (id == 0)
                 id = Convert.ToInt32(value);
         }

--- a/Dapper.Tests.Contrib/Dapper.Tests.Contrib.csproj
+++ b/Dapper.Tests.Contrib/Dapper.Tests.Contrib.csproj
@@ -6,13 +6,14 @@
     <DebugType>portable</DebugType>
     <OutputType>Exe</OutputType>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <TargetFrameworks>netcoreapp1.0;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Dapper.Tests\Helpers\XunitSkippable.cs;..\Dapper\TypeExtensions.cs" />
     <None Remove="Test.DB.sdf" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Npgsql" Version="3.2.5" />
     <ProjectReference Include="..\Dapper\Dapper.csproj" />
     <ProjectReference Include="..\Dapper.Contrib\Dapper.Contrib.csproj" />
     <ProjectReference Include="..\Dapper.SqlBuilder\Dapper.SqlBuilder.csproj" />

--- a/Dapper.Tests.Contrib/Dapper.Tests.Contrib.csproj
+++ b/Dapper.Tests.Contrib/Dapper.Tests.Contrib.csproj
@@ -6,7 +6,7 @@
     <DebugType>portable</DebugType>
     <OutputType>Exe</OutputType>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <TargetFrameworks>netcoreapp1.0;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Dapper.Tests\Helpers\XunitSkippable.cs;..\Dapper\TypeExtensions.cs" />

--- a/Dapper.Tests.Contrib/Dapper.Tests.Contrib.csproj
+++ b/Dapper.Tests.Contrib/Dapper.Tests.Contrib.csproj
@@ -6,7 +6,7 @@
     <DebugType>portable</DebugType>
     <OutputType>Exe</OutputType>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.0;netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Dapper.Tests\Helpers\XunitSkippable.cs;..\Dapper\TypeExtensions.cs" />

--- a/Dapper.Tests.Contrib/TestSuite.Async.cs
+++ b/Dapper.Tests.Contrib/TestSuite.Async.cs
@@ -226,9 +226,9 @@ namespace Dapper.Tests.Contrib
 
                 var builder = new SqlBuilder();
                 var justId = builder.AddTemplate("SELECT /**select**/ FROM Users");
-                var all = builder.AddTemplate("SELECT Name, /**select**/, Age FROM Users");
+                var all = builder.AddTemplate($"SELECT {FormatIdentifier("Name")}, /**select**/, {FormatIdentifier("Age")} FROM Users");
 
-                builder.Select("Id");
+                builder.Select(FormatIdentifier("Id"));
 
                 var ids = await connection.QueryAsync<int>(justId.RawSql, justId.Parameters).ConfigureAwait(false);
                 var users = await connection.QueryAsync<User>(all.RawSql, all.Parameters).ConfigureAwait(false);
@@ -246,7 +246,7 @@ namespace Dapper.Tests.Contrib
         public async Task BuilderTemplateWithoutCompositionAsync()
         {
             var builder = new SqlBuilder();
-            var template = builder.AddTemplate("SELECT COUNT(*) FROM Users WHERE Age = @age", new { age = 5 });
+            var template = builder.AddTemplate($"SELECT COUNT(*) FROM Users WHERE {FormatIdentifier("Age")} = @age", new { age = 5 });
 
             if (template.RawSql == null) throw new Exception("RawSql null");
             if (template.Parameters == null) throw new Exception("Parameters null");

--- a/Dapper.Tests.Contrib/TestSuite.Async.cs
+++ b/Dapper.Tests.Contrib/TestSuite.Async.cs
@@ -228,7 +228,7 @@ namespace Dapper.Tests.Contrib
                 var justId = builder.AddTemplate("SELECT /**select**/ FROM Users");
                 var all = builder.AddTemplate($"SELECT {FormatIdentifier("Name")}, /**select**/, {FormatIdentifier("Age")} FROM Users");
 
-                builder.Select(FormatIdentifier("Id"));
+                builder.Select("Id");
 
                 var ids = await connection.QueryAsync<int>(justId.RawSql, justId.Parameters).ConfigureAwait(false);
                 var users = await connection.QueryAsync<User>(all.RawSql, all.Parameters).ConfigureAwait(false);

--- a/Dapper.Tests.Contrib/TestSuite.cs
+++ b/Dapper.Tests.Contrib/TestSuite.cs
@@ -702,7 +702,7 @@ namespace Dapper.Tests.Contrib
                 var justId = builder.AddTemplate("SELECT /**select**/ FROM Users");
                 var all = builder.AddTemplate($"SELECT {FormatIdentifier("Name")}, /**select**/, {FormatIdentifier("Age")} FROM Users");
 
-                builder.Select(FormatIdentifier("Id"));
+                builder.Select("Id");
 
                 var ids = connection.Query<int>(justId.RawSql, justId.Parameters);
                 var users = connection.Query<User>(all.RawSql, all.Parameters);

--- a/Dapper.Tests.Contrib/TestSuite.cs
+++ b/Dapper.Tests.Contrib/TestSuite.cs
@@ -111,6 +111,7 @@ namespace Dapper.Tests.Contrib
         protected static readonly bool IsAppVeyor = Environment.GetEnvironmentVariable("Appveyor")?.ToUpperInvariant() == "TRUE";
 
         public abstract IDbConnection GetConnection();
+        public virtual string FormatIdentifier(string identifier) => identifier;
 
         private IDbConnection GetOpenConnection()
         {
@@ -699,9 +700,9 @@ namespace Dapper.Tests.Contrib
 
                 var builder = new SqlBuilder();
                 var justId = builder.AddTemplate("SELECT /**select**/ FROM Users");
-                var all = builder.AddTemplate("SELECT Name, /**select**/, Age FROM Users");
+                var all = builder.AddTemplate($"SELECT {FormatIdentifier("Name")}, /**select**/, {FormatIdentifier("Age")} FROM Users");
 
-                builder.Select("Id");
+                builder.Select(FormatIdentifier("Id"));
 
                 var ids = connection.Query<int>(justId.RawSql, justId.Parameters);
                 var users = connection.Query<User>(all.RawSql, all.Parameters);
@@ -718,7 +719,7 @@ namespace Dapper.Tests.Contrib
         public void BuilderTemplateWithoutComposition()
         {
             var builder = new SqlBuilder();
-            var template = builder.AddTemplate("SELECT COUNT(*) FROM Users WHERE Age = @age", new { age = 5 });
+            var template = builder.AddTemplate($"SELECT COUNT(*) FROM Users WHERE {FormatIdentifier("Age")} = @age", new { age = 5 });
 
             if (template.RawSql == null) throw new Exception("RawSql null");
             if (template.Parameters == null) throw new Exception("Parameters null");

--- a/Dapper.Tests.Contrib/TestSuites.cs
+++ b/Dapper.Tests.Contrib/TestSuites.cs
@@ -80,25 +80,25 @@ namespace Dapper.Tests.Contrib
                 void dropTable(string name) => connection.Execute($"DROP TABLE IF EXISTS {name}; ");
                 connection.Open();
                 dropTable("Stuff");
-                connection.Execute("CREATE TABLE Stuff (\"TheId\" serial not null, \"Name\" varchar(100) not null, \"Created\" timestamp null);");
+                connection.Execute("CREATE TABLE Stuff (TheId serial not null, \"Name\" varchar(100) not null, \"Created\" timestamp null);");
                 dropTable("People");
-                connection.Execute("CREATE TABLE People (\"Id\" serial not null, \"Name\" varchar(100) not null);");
+                connection.Execute("CREATE TABLE People (Id serial not null, \"Name\" varchar(100) not null);");
                 dropTable("\"users\"");
-                connection.Execute("CREATE TABLE \"users\" (\"Id\" serial not null, \"Name\" varchar(100) not null, \"Age\" int not null);");
+                connection.Execute("CREATE TABLE \"users\" (Id serial not null, \"Name\" varchar(100) not null, \"Age\" int not null);");
                 dropTable("Automobiles");
-                connection.Execute("CREATE TABLE Automobiles (\"Id\" serial not null, \"Name\" varchar(100) not null);");
+                connection.Execute("CREATE TABLE Automobiles (Id serial not null, \"Name\" varchar(100) not null);");
                 dropTable("Results");
-                connection.Execute("CREATE TABLE Results (\"Id\" serial not null, \"Name\" varchar(100) not null, \"Order\" int not null);");
+                connection.Execute("CREATE TABLE Results (Id serial not null, \"Name\" varchar(100) not null, \"Order\" int not null);");
                 dropTable("ObjectX");
-                connection.Execute("CREATE TABLE ObjectX (\"ObjectXId\" varchar(100) not null, \"Name\" varchar(100) not null);");
+                connection.Execute("CREATE TABLE ObjectX (ObjectXId varchar(100) not null, \"Name\" varchar(100) not null);");
                 dropTable("ObjectY");
-                connection.Execute("CREATE TABLE ObjectY (\"ObjectYId\" int not null, \"Name\" varchar(100) not null);");
+                connection.Execute("CREATE TABLE ObjectY (ObjectYId int not null, \"Name\" varchar(100) not null);");
                 dropTable("ObjectZ");
-                connection.Execute("CREATE TABLE ObjectZ (\"Id\" int not null, \"Name\" varchar(100) not null);");
+                connection.Execute("CREATE TABLE ObjectZ (Id int not null, \"Name\" varchar(100) not null);");
                 dropTable("GenericType");
-                connection.Execute("CREATE TABLE GenericType (\"Id\" varchar(100) not null, \"Name\" varchar(100) not null);");
+                connection.Execute("CREATE TABLE GenericType (Id varchar(100) not null, \"Name\" varchar(100) not null);");
                 dropTable("NullableDates");
-                connection.Execute("CREATE TABLE NullableDates (\"Id\" serial not null, \"DateValue\" timestamp null);");
+                connection.Execute("CREATE TABLE NullableDates (Id serial not null, \"DateValue\" timestamp null);");
             }
         }
     }

--- a/Dapper.Tests.Contrib/TestSuites.cs
+++ b/Dapper.Tests.Contrib/TestSuites.cs
@@ -63,6 +63,46 @@ namespace Dapper.Tests.Contrib
         }
     }
 
+    public class PostgresqlTestSuite : TestSuite
+    {
+        public static string ConnectionString =>
+            IsAppVeyor
+                ? "Server=localhost;Port=5432;User Id=postgres;Password=Password12!;Database=test"
+                : "Server=localhost;Port=5432;User Id=dappertest;Password=dapperpass;Database=dappertest"; // ;Encoding = UNICODE
+        public override IDbConnection GetConnection() => new Npgsql.NpgsqlConnection(ConnectionString);
+        public override string FormatIdentifier(string identifier) => $"\"{identifier}\"";
+
+        static PostgresqlTestSuite()
+        {
+            using (var connection = new Npgsql.NpgsqlConnection(ConnectionString))
+            {
+                // ReSharper disable once AccessToDisposedClosure
+                void dropTable(string name) => connection.Execute($"DROP TABLE IF EXISTS {name}; ");
+                connection.Open();
+                dropTable("Stuff");
+                connection.Execute("CREATE TABLE Stuff (\"TheId\" serial not null, \"Name\" varchar(100) not null, \"Created\" timestamp null);");
+                dropTable("People");
+                connection.Execute("CREATE TABLE People (\"Id\" serial not null, \"Name\" varchar(100) not null);");
+                dropTable("\"users\"");
+                connection.Execute("CREATE TABLE \"users\" (\"Id\" serial not null, \"Name\" varchar(100) not null, \"Age\" int not null);");
+                dropTable("Automobiles");
+                connection.Execute("CREATE TABLE Automobiles (\"Id\" serial not null, \"Name\" varchar(100) not null);");
+                dropTable("Results");
+                connection.Execute("CREATE TABLE Results (\"Id\" serial not null, \"Name\" varchar(100) not null, \"Order\" int not null);");
+                dropTable("ObjectX");
+                connection.Execute("CREATE TABLE ObjectX (\"ObjectXId\" varchar(100) not null, \"Name\" varchar(100) not null);");
+                dropTable("ObjectY");
+                connection.Execute("CREATE TABLE ObjectY (\"ObjectYId\" int not null, \"Name\" varchar(100) not null);");
+                dropTable("ObjectZ");
+                connection.Execute("CREATE TABLE ObjectZ (\"Id\" int not null, \"Name\" varchar(100) not null);");
+                dropTable("GenericType");
+                connection.Execute("CREATE TABLE GenericType (\"Id\" varchar(100) not null, \"Name\" varchar(100) not null);");
+                dropTable("NullableDates");
+                connection.Execute("CREATE TABLE NullableDates (\"Id\" serial not null, \"DateValue\" timestamp null);");
+            }
+        }
+    }
+
     public class MySqlServerTestSuite : TestSuite
     {
         public static string ConnectionString { get; } =


### PR DESCRIPTION
I realise this is technically a change in behaviour but it actually represents a standardisation in how postgres column names are treated. 

This is intended to add quotes to all column names when using postgres. The current behaviour omits quotes for id column on get and also on insert when getting an id back but uses quotes for all other operations and columns.

My personal preference would be to support snake_case names and not use quotes at all as this is more in line with postgres standard practise. I realise this has been talked about in #722 

Note that this change does not affect the fact the Contrib currently does not quote table names so there is still an inconsistency between table and column name handling.