### PR TITLE
Parsing using customtypehandler as a first step

### DIFF
--- a/Dapper.Tests/TupleTests.cs
+++ b/Dapper.Tests/TupleTests.cs
@@ -98,5 +98,19 @@ namespace Dapper.Tests
             Assert.Equal(14, val.e14);
             Assert.Equal(15, val.e15);
         }
+
+        [Fact]
+        public void TupleReturnValue_Works_WithStringField()
+        {
+            var val = connection.QuerySingle<ValueTuple<string>>("select '42'");
+            Assert.Equal("42", val.Item1);
+        }
+
+        [Fact]
+        public void TupleReturnValue_Works_WithByteField()
+        {
+            var val = connection.QuerySingle<ValueTuple<byte[]>>("select 0xDEADBEEF");
+            Assert.Equal(new byte[] { 0xDE, 0xAD, 0xBE, 0xEF }, val.Item1);
+        }
     }
 }


### PR DESCRIPTION
custom typehandlers should be used at the beginning of the LoadReadeValue and not in the end.

We have a custom enums properties which the current behavior throw an error, because it assumes to be enum (target property). 
Moving Custom-typehandler check at the beginning of the flow allows custom behavior before Dapper logic per property