### PR TITLE
Added support to SQLAnywhere Database / ODBC

### DIFF
--- a/Dapper.Contrib/Dapper.Contrib.csproj
+++ b/Dapper.Contrib/Dapper.Contrib.csproj
@@ -7,6 +7,8 @@
     <Authors>Sam Saffron;Johan Danforth</Authors>
     <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageId>KubePackages.Dapper.Contrib</PackageId>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Dapper\Dapper.csproj" />

--- a/Dapper.Contrib/SqlMapperExtensions.Async.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.Async.cs
@@ -32,12 +32,12 @@ namespace Dapper.Contrib.Extensions
                 var key = GetSingleKey<T>(nameof(GetAsync));
                 var name = GetTableName(type);
 
-                sql = $"SELECT * FROM {name} WHERE {key.Name} = {adapter.GetParametersPrefix()}id";
+                sql = $"SELECT * FROM {name} WHERE {key.Name} = {adapter.GetFormattedParameter("id")}";
                 GetQueries[type.TypeHandle] = sql;
             }
 
             var dynParms = new DynamicParameters();
-            dynParms.Add(adapter.GetParametersPrefix() + "id", id);
+            dynParms.Add(adapter.GetFormattedParameter("id"), id);
 
             if (!type.IsInterface)
                 return (await connection.QueryAsync<T>(sql, dynParms, transaction, commandTimeout).ConfigureAwait(false)).FirstOrDefault();
@@ -183,7 +183,7 @@ namespace Dapper.Contrib.Extensions
             for (var i = 0; i < allPropertiesExceptKeyAndComputed.Count; i++)
             {
                 var property = allPropertiesExceptKeyAndComputed[i];
-                sbParameterList.AppendFormat(sqlAdapter.GetParametersPrefix() + "{0}", property.Name);
+                sbParameterList.AppendFormat(sqlAdapter.GetFormattedParameter("{0}"), property.Name);
                 if (i < allPropertiesExceptKeyAndComputed.Count - 1)
                     sbParameterList.Append(", ");
             }

--- a/Dapper.Contrib/SqlMapperExtensions.Async.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.Async.cs
@@ -25,17 +25,19 @@ namespace Dapper.Contrib.Extensions
         public static async Task<T> GetAsync<T>(this IDbConnection connection, dynamic id, IDbTransaction transaction = null, int? commandTimeout = null) where T : class
         {
             var type = typeof(T);
+            var adapter = GetFormatter(connection);
+
             if (!GetQueries.TryGetValue(type.TypeHandle, out string sql))
             {
                 var key = GetSingleKey<T>(nameof(GetAsync));
                 var name = GetTableName(type);
 
-                sql = $"SELECT * FROM {name} WHERE {key.Name} = @id";
+                sql = $"SELECT * FROM {name} WHERE {key.Name} = {adapter.GetParametersPrefix()}id";
                 GetQueries[type.TypeHandle] = sql;
             }
 
             var dynParms = new DynamicParameters();
-            dynParms.Add("@id", id);
+            dynParms.Add(adapter.GetParametersPrefix() + "id", id);
 
             if (!type.IsInterface)
                 return (await connection.QueryAsync<T>(sql, dynParms, transaction, commandTimeout).ConfigureAwait(false)).FirstOrDefault();
@@ -181,7 +183,7 @@ namespace Dapper.Contrib.Extensions
             for (var i = 0; i < allPropertiesExceptKeyAndComputed.Count; i++)
             {
                 var property = allPropertiesExceptKeyAndComputed[i];
-                sbParameterList.AppendFormat("@{0}", property.Name);
+                sbParameterList.AppendFormat(sqlAdapter.GetParametersPrefix() + "{0}", property.Name);
                 if (i < allPropertiesExceptKeyAndComputed.Count - 1)
                     sbParameterList.Append(", ");
             }
@@ -573,5 +575,38 @@ public partial class FbAdapter
         idp.SetValue(entityToInsert, Convert.ChangeType(id, idp.PropertyType), null);
 
         return Convert.ToInt32(id);
+    }
+}
+
+public partial class SqlAnywhereAdapter
+{
+    /// <summary>
+    /// Inserts <paramref name="entityToInsert"/> into the database, returning the Id of the row created.
+    /// </summary>
+    /// <param name="connection">The connection to use.</param>
+    /// <param name="transaction">The transaction to use.</param>
+    /// <param name="commandTimeout">The command timeout to use.</param>
+    /// <param name="tableName">The table to insert into.</param>
+    /// <param name="columnList">The columns to set with this insert.</param>
+    /// <param name="parameterList">The parameters to set for this insert.</param>
+    /// <param name="keyProperties">The key columns in this table.</param>
+    /// <param name="entityToInsert">The entity to insert.</param>
+    /// <returns>The Id of the row created.</returns>
+    public async Task<int> InsertAsync(IDbConnection connection, IDbTransaction transaction, int? commandTimeout, string tableName, string columnList, string parameterList, IEnumerable<PropertyInfo> keyProperties, object entityToInsert)
+    {
+        var cmd = $"INSERT INTO {tableName} ({columnList}) values ({parameterList}); SELECT @@identity id";
+        var multi = await connection.QueryMultipleAsync(cmd, entityToInsert, transaction, commandTimeout).ConfigureAwait(false);
+
+        var first = multi.Read().FirstOrDefault();
+        if (first == null || first.id == null) return 0;
+
+        var id = (int)first.id;
+        var pi = keyProperties as PropertyInfo[] ?? keyProperties.ToArray();
+        if (pi.Length == 0) return id;
+
+        var idp = pi[0];
+        idp.SetValue(entityToInsert, Convert.ChangeType(id, idp.PropertyType), null);
+
+        return id;
     }
 }

--- a/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.cs
@@ -246,12 +246,12 @@ namespace Dapper.Contrib.Extensions
                 var key = GetSingleKey<T>(nameof(Get));
                 var name = GetTableName(type);
 
-                sql = $"select * from {name} where {key.Name} = {adapter.GetParametersPrefix()}id";
+                sql = $"select * from {name} where {key.Name} = {adapter.GetFormattedParameter("id")}";
                 GetQueries[type.TypeHandle] = sql;
             }
 
             var dynParms = new DynamicParameters();
-            dynParms.Add($"{adapter.GetParametersPrefix()}id", id);
+            dynParms.Add(adapter.GetFormattedParameter("id"), id);
 
             T obj;
 
@@ -431,7 +431,7 @@ namespace Dapper.Contrib.Extensions
             for (var i = 0; i < allPropertiesExceptKeyAndComputed.Count; i++)
             {
                 var property = allPropertiesExceptKeyAndComputed[i];
-                sbParameterList.AppendFormat(adapter.GetParametersPrefix() + (adapter.GetForcePositionalParameters() ? "?{0}?" : "{0}"), property.Name);
+                sbParameterList.AppendFormat(adapter.GetFormattedParameter("{0}"), property.Name);
                 if (i < allPropertiesExceptKeyAndComputed.Count - 1)
                     sbParameterList.Append(", ");
             }
@@ -852,6 +852,13 @@ public partial interface ISqlAdapter
     bool GetForcePositionalParameters();
 
     /// <summary>
+    /// Returns the parameter formatted to be used inside of a query
+    /// </summary>
+    /// <param name="columnName"></param>
+    /// <returns></returns>
+    string GetFormattedParameter(string columnName);
+
+    /// <summary>
     /// Inserts <paramref name="entityToInsert"/> into the database, returning the Id of the row created.
     /// </summary>
     /// <param name="connection">The connection to use.</param>
@@ -929,7 +936,7 @@ public partial class SqlServerAdapter : ISqlAdapter
     /// <summary>
     /// Adds the name of a column.
     /// </summary>
-    /// <param name="sb">The string builder  to append to.</param>
+    /// <param name="sb">The string builder to append to.</param>
     /// <param name="columnName">The column name.</param>
     public void AppendColumnName(StringBuilder sb, string columnName)
     {
@@ -943,7 +950,24 @@ public partial class SqlServerAdapter : ISqlAdapter
     /// <param name="columnName">The column name.</param>
     public void AppendColumnNameEqualsValue(StringBuilder sb, string columnName)
     {
-        sb.AppendFormat("[{0}] = {1}", columnName, GetParametersPrefix() + columnName);
+        sb.AppendFormat("[{0}] = {1}", columnName, GetFormattedParameter(columnName));
+    }
+
+    /// <summary>
+    /// Returns the parameter formatted to be used inside of a query
+    /// </summary>
+    /// <param name="columnName"></param>
+    /// <returns></returns>
+    public string GetFormattedParameter(string columnName)
+    {
+        if (GetForcePositionalParameters())
+        {
+            return "?" + columnName + "?";
+        }
+        else
+        {
+            return GetParametersPrefix() + columnName;
+        }
     }
 }
 
@@ -1011,7 +1035,24 @@ public partial class SqlCeServerAdapter : ISqlAdapter
     /// <param name="columnName">The column name.</param>
     public void AppendColumnNameEqualsValue(StringBuilder sb, string columnName)
     {
-        sb.AppendFormat("[{0}] = {1}", columnName, GetParametersPrefix() + columnName);
+        sb.AppendFormat("[{0}] = {1}", columnName, GetFormattedParameter(columnName));
+    }
+
+    /// <summary>
+    /// Returns the parameter formatted to be used inside of a query
+    /// </summary>
+    /// <param name="columnName"></param>
+    /// <returns></returns>
+    public string GetFormattedParameter(string columnName)
+    {
+        if (GetForcePositionalParameters())
+        {
+            return "?" + columnName + "?";
+        }
+        else
+        {
+            return GetParametersPrefix() + columnName;
+        }
     }
 }
 
@@ -1078,7 +1119,24 @@ public partial class MySqlAdapter : ISqlAdapter
     /// <param name="columnName">The column name.</param>
     public void AppendColumnNameEqualsValue(StringBuilder sb, string columnName)
     {
-        sb.AppendFormat("`{0}` = {1}", columnName, GetParametersPrefix() + columnName);
+        sb.AppendFormat("`{0}` = {1}", columnName, GetFormattedParameter(columnName));
+    }
+
+    /// <summary>
+    /// Returns the parameter formatted to be used inside of a query
+    /// </summary>
+    /// <param name="columnName"></param>
+    /// <returns></returns>
+    public string GetFormattedParameter(string columnName)
+    {
+        if (GetForcePositionalParameters())
+        {
+            return "?" + columnName + "?";
+        }
+        else
+        {
+            return GetParametersPrefix() + columnName;
+        }
     }
 }
 
@@ -1166,7 +1224,24 @@ public partial class PostgresAdapter : ISqlAdapter
     /// <param name="columnName">The column name.</param>
     public void AppendColumnNameEqualsValue(StringBuilder sb, string columnName)
     {
-        sb.AppendFormat("\"{0}\" = {1}", columnName, GetParametersPrefix() + columnName);
+        sb.AppendFormat("\"{0}\" = {1}", columnName, GetFormattedParameter(columnName));
+    }
+
+    /// <summary>
+    /// Returns the parameter formatted to be used inside of a query
+    /// </summary>
+    /// <param name="columnName"></param>
+    /// <returns></returns>
+    public string GetFormattedParameter(string columnName)
+    {
+        if (GetForcePositionalParameters())
+        {
+            return "?" + columnName + "?";
+        }
+        else
+        {
+            return GetParametersPrefix() + columnName;
+        }
     }
 }
 
@@ -1231,7 +1306,24 @@ public partial class SQLiteAdapter : ISqlAdapter
     /// <param name="columnName">The column name.</param>
     public void AppendColumnNameEqualsValue(StringBuilder sb, string columnName)
     {
-        sb.AppendFormat("\"{0}\" = {1}", columnName, GetParametersPrefix() + columnName);
+        sb.AppendFormat("\"{0}\" = {1}", columnName, GetFormattedParameter(columnName));
+    }
+
+    /// <summary>
+    /// Returns the parameter formatted to be used inside of a query
+    /// </summary>
+    /// <param name="columnName"></param>
+    /// <returns></returns>
+    public string GetFormattedParameter(string columnName)
+    {
+        if (GetForcePositionalParameters())
+        {
+            return "?" + columnName + "?";
+        }
+        else
+        {
+            return GetParametersPrefix() + columnName;
+        }
     }
 }
 
@@ -1300,7 +1392,24 @@ public partial class FbAdapter : ISqlAdapter
     /// <param name="columnName">The column name.</param>
     public void AppendColumnNameEqualsValue(StringBuilder sb, string columnName)
     {
-        sb.AppendFormat("{0} = {1}", columnName, GetParametersPrefix() + columnName);
+        sb.AppendFormat("{0} = {1}", columnName, GetFormattedParameter(columnName));
+    }
+
+    /// <summary>
+    /// Returns the parameter formatted to be used inside of a query
+    /// </summary>
+    /// <param name="columnName"></param>
+    /// <returns></returns>
+    public string GetFormattedParameter(string columnName)
+    {
+        if (GetForcePositionalParameters())
+        {
+            return "?" + columnName + "?";
+        }
+        else
+        {
+            return GetParametersPrefix() + columnName;
+        }
     }
 }
 
@@ -1368,6 +1477,23 @@ public partial class SqlAnywhereAdapter : ISqlAdapter
     /// <param name="columnName">The column name.</param>
     public void AppendColumnNameEqualsValue(StringBuilder sb, string columnName)
     {
-        sb.AppendFormat("{0} = {1}", columnName, GetParametersPrefix() + columnName);
+        sb.AppendFormat("{0} = {1}", columnName, GetFormattedParameter(columnName));
+    }
+
+    /// <summary>
+    /// Returns the parameter formatted to be used inside of a query
+    /// </summary>
+    /// <param name="columnName"></param>
+    /// <returns></returns>
+    public string GetFormattedParameter(string columnName)
+    {
+        if (GetForcePositionalParameters())
+        {
+            return "?" + columnName + "?";
+        }
+        else
+        {
+            return GetParametersPrefix() + columnName;
+        }
     }
 }

--- a/Dapper/Dapper.csproj
+++ b/Dapper/Dapper.csproj
@@ -6,6 +6,8 @@
     <Description>A high performance Micro-ORM supporting SQL Server, MySQL, Sqlite, SqlCE, Firebird etc..</Description>
     <Authors>Sam Saffron;Marc Gravell;Nick Craver</Authors>
     <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <PackageId>KubePackages.Dapper</PackageId>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
   
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">


### PR DESCRIPTION
I've added support to SAP Sybase SQL Anywhere Database.
This database uses ":" insted of "@" to identify query parameters.
It also requires an ODBC connection and does not support named parameters.
Because of this I've added two functions to the ISqlAdapter interface:
 - GetParametersPrefix to get the correct prefix for the database
 - GetForcePositionalParameters to force the parameters to be positional in Insert/update statements

I've then added a method to set the default Database provider (to be used insted of hard coded SQL Server) because the ODBC connection does not report provider's name:
 - SetDefaultAdapter

I've tried to make it as simple as possible and it should have zero impact on existing code.