### PR TITLE
Allow checking for custom handlers outside Dapper library

### DIFF
--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -260,8 +260,12 @@ namespace Dapper
         /// <param name="type">The type to handle.</param>
         /// <param name="handler">The handler to process the <paramref name="type"/>.</param>
         public static void AddTypeHandler(Type type, ITypeHandler handler) => AddTypeHandlerImpl(type, handler, true);
-
-        internal static bool HasTypeHandler(Type type) => typeHandlers.ContainsKey(type);
+        /// <summary>
+        /// Determine if the specified type will be processed by a custom handler.
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        public static bool HasTypeHandler(Type type) => typeHandlers.ContainsKey(type);
 
         /// <summary>
         /// Configure the specified type to be processed by a custom handler.

--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -263,8 +263,8 @@ namespace Dapper
         /// <summary>
         /// Determine if the specified type will be processed by a custom handler.
         /// </summary>
-        /// <param name="type"></param>
-        /// <returns></returns>
+        /// <param name="type">The type to handle.</param>
+        /// <returns>Boolean value specifying whether the type will be processed by a custom handler.</returns>
         public static bool HasTypeHandler(Type type) => typeHandlers.ContainsKey(type);
 
         /// <summary>


### PR DESCRIPTION
Allow checking for whether a type will be handled by a custom handlers outside Dapper library (For use in SimpleCRUD extension)