### PR TITLE
Avoid exception if the key is not Int32

### DIFF
--- a/Dapper.Contrib/SqlMapperExtensions.Async.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.Async.cs
@@ -506,7 +506,9 @@ public partial class PostgresAdapter
             var value = ((IDictionary<string, object>)results.First())[p.Name.ToLower()];
             p.SetValue(entityToInsert, value, null);
             if (id == 0)
-                id = Convert.ToInt32(value);
+            {
+                TryToInt32(value, out id);
+            }
         }
         return id;
     }


### PR DESCRIPTION
I experience an issue when the key typed as GUID so that I was forced to prepare a custom `ISqlAdapter`, copy paste the code and remove the conversion to int. That's why I suggest checking the type before we cast the result. If you find the change useful we can do the same for other adapters too. Just let me know and I will do it.