### PR TITLE
Prevent race conditions

### DIFF
--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -290,29 +290,32 @@ namespace Dapper
                 }
             }
 
-            var snapshot = typeHandlers;
-            if (snapshot.TryGetValue(type, out ITypeHandler oldValue) && handler == oldValue) return; // nothing to do
+            lock (typeHandlersLocker)
+            {
+                var snapshot = typeHandlers;
+                if (snapshot.TryGetValue(type, out ITypeHandler oldValue) && handler == oldValue) return; // nothing to do
 
-            var newCopy = clone ? new Dictionary<Type, ITypeHandler>(snapshot) : snapshot;
+                var newCopy = clone ? new Dictionary<Type, ITypeHandler>(snapshot) : snapshot;
 
-#pragma warning disable 618
-            typeof(TypeHandlerCache<>).MakeGenericType(type).GetMethod(nameof(TypeHandlerCache<int>.SetHandler), BindingFlags.Static | BindingFlags.NonPublic).Invoke(null, new object[] { handler });
-            if (secondary != null)
-            {
-                typeof(TypeHandlerCache<>).MakeGenericType(secondary).GetMethod(nameof(TypeHandlerCache<int>.SetHandler), BindingFlags.Static | BindingFlags.NonPublic).Invoke(null, new object[] { handler });
+    #pragma warning disable 618
+                typeof(TypeHandlerCache<>).MakeGenericType(type).GetMethod(nameof(TypeHandlerCache<int>.SetHandler), BindingFlags.Static | BindingFlags.NonPublic).Invoke(null, new object[] { handler });
+                if (secondary != null)
+                {
+                    typeof(TypeHandlerCache<>).MakeGenericType(secondary).GetMethod(nameof(TypeHandlerCache<int>.SetHandler), BindingFlags.Static | BindingFlags.NonPublic).Invoke(null, new object[] { handler });
+                }
+    #pragma warning restore 618
+                if (handler == null)
+                {
+                    newCopy.Remove(type);
+                    if (secondary != null) newCopy.Remove(secondary);
+                }
+                else
+                {
+                    newCopy[type] = handler;
+                    if (secondary != null) newCopy[secondary] = handler;
+                }
+                typeHandlers = newCopy;
             }
-#pragma warning restore 618
-            if (handler == null)
-            {
-                newCopy.Remove(type);
-                if (secondary != null) newCopy.Remove(secondary);
-            }
-            else
-            {
-                newCopy[type] = handler;
-                if (secondary != null) newCopy[secondary] = handler;
-            }
-            typeHandlers = newCopy;
         }
 
         /// <summary>
@@ -323,6 +326,7 @@ namespace Dapper
         public static void AddTypeHandler<T>(TypeHandler<T> handler) => AddTypeHandlerImpl(typeof(T), handler, true);
 
         private static Dictionary<Type, ITypeHandler> typeHandlers;
+        private static object typeHandlersLocker = new object();
 
         internal const string LinqBinary = "System.Data.Linq.Binary";
 


### PR DESCRIPTION
Our application's init process is paralleled for some reasons
And some developers in their own parts of code use AddTypeHandlerImpl for their own handlers
But in really rarelly moments we received exception like this: Invalid cast from 'System.String' to 'Newtonsoft.Json.Linq.JObject' (and yet another random classes)
Why: because typeHandlers didn't contain an appropriate handler)

Of cause race fixed by some changes in our code, but we would like have fix here, if it's possible