### PR TITLE
.Net 5

### DIFF
--- a/Dapper.Contrib/Dapper.Contrib.csproj
+++ b/Dapper.Contrib/Dapper.Contrib.csproj
@@ -7,6 +7,7 @@
     <Authors>Sam Saffron;Johan Danforth</Authors>
     <TargetFrameworks>net461;netstandard2.0;net5.0</TargetFrameworks>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <NoWarn>$(NoWarn);CA1050</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Dapper\Dapper.csproj" />

--- a/Dapper.Contrib/Dapper.Contrib.csproj
+++ b/Dapper.Contrib/Dapper.Contrib.csproj
@@ -5,7 +5,7 @@
     <PackageTags>orm;sql;micro-orm;dapper</PackageTags>
     <Description>The official collection of get, insert, update and delete helpers for Dapper.net. Also handles lists of entities and optional "dirty" tracking of interface-based entities.</Description>
     <Authors>Sam Saffron;Johan Danforth</Authors>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;net5.0</TargetFrameworks>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>

--- a/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.cs
@@ -187,10 +187,10 @@ namespace Dapper.Contrib.Extensions
 
             if (type.IsInterface)
             {
-                var res = connection.Query(sql, dynParams).FirstOrDefault() as IDictionary<string, object>;
-
-                if (res == null)
+                if (!(connection.Query(sql, dynParams).FirstOrDefault() is IDictionary<string, object> res))
+                {
                     return null;
+                }
 
                 obj = ProxyGenerator.GetInterfaceProxy<T>();
 
@@ -273,7 +273,9 @@ namespace Dapper.Contrib.Extensions
         /// <summary>
         /// Specify a custom table name mapper based on the POCO type name
         /// </summary>
+#pragma warning disable CA2211 // Non-constant fields should not be visible - I agree with you, but we can't do that until we break the API
         public static TableNameMapperDelegate TableNameMapper;
+#pragma warning restore CA2211 // Non-constant fields should not be visible
 
         private static string GetTableName(Type type)
         {
@@ -534,7 +536,9 @@ namespace Dapper.Contrib.Extensions
         /// Specifies a custom callback that detects the database type instead of relying on the default strategy (the name of the connection type object).
         /// Please note that this callback is global and will be used by all the calls that require a database specific adapter.
         /// </summary>
+#pragma warning disable CA2211 // Non-constant fields should not be visible - I agree with you, but we can't do that until we break the API
         public static GetDatabaseTypeDelegate GetDatabaseType;
+#pragma warning restore CA2211 // Non-constant fields should not be visible
 
         private static ISqlAdapter GetFormatter(IDbConnection connection)
         {
@@ -552,7 +556,7 @@ namespace Dapper.Contrib.Extensions
 
             private static AssemblyBuilder GetAsmBuilder(string name)
             {
-#if NETSTANDARD2_0
+#if !NET461
                 return AssemblyBuilder.DefineDynamicAssembly(new AssemblyName { Name = name }, AssemblyBuilderAccess.Run);
 #else
                 return Thread.GetDomain().DefineDynamicAssembly(new AssemblyName { Name = name }, AssemblyBuilderAccess.Run);
@@ -681,8 +685,8 @@ namespace Dapper.Contrib.Extensions
                 if (isIdentity)
                 {
                     var keyAttribute = typeof(KeyAttribute);
-                    var myConstructorInfo = keyAttribute.GetConstructor(new Type[] { });
-                    var attributeBuilder = new CustomAttributeBuilder(myConstructorInfo, new object[] { });
+                    var myConstructorInfo = keyAttribute.GetConstructor(Type.EmptyTypes);
+                    var attributeBuilder = new CustomAttributeBuilder(myConstructorInfo, Array.Empty<object>());
                     property.SetCustomAttribute(attributeBuilder);
                 }
 

--- a/Dapper.EntityFramework/DbGeometryHandler.cs
+++ b/Dapper.EntityFramework/DbGeometryHandler.cs
@@ -35,9 +35,9 @@ namespace Dapper.EntityFramework
                 parsed = SqlGeometry.STGeomFromWKB(new SqlBytes(value.AsBinary()), value.CoordinateSystemId);
             }
             parameter.Value = parsed ?? DBNull.Value;
-            if (parameter is SqlParameter)
+            if (parameter is SqlParameter sqlP)
             {
-                ((SqlParameter)parameter).UdtTypeName = "geometry";
+                sqlP.UdtTypeName = "geometry";
             }
         }
 

--- a/Dapper.ProviderTools/BulkCopy.cs
+++ b/Dapper.ProviderTools/BulkCopy.cs
@@ -136,7 +136,11 @@ namespace Dapper.ProviderTools
         /// <summary>
         /// Release any resources associated with this instance
         /// </summary>
-        public void Dispose() => Dispose(true);
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
 
         /// <summary>
         /// Release any resources associated with this instance

--- a/Dapper.ProviderTools/Dapper.ProviderTools.csproj
+++ b/Dapper.ProviderTools/Dapper.ProviderTools.csproj
@@ -5,7 +5,7 @@
     <Title>Dapper Provider Tools</Title>
     <Description>Provider-agnostic ADO.NET helper utilities</Description>
     <Authors>Marc Gravell</Authors>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;net5.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Dapper.Rainbow/Dapper.Rainbow.csproj
+++ b/Dapper.Rainbow/Dapper.Rainbow.csproj
@@ -6,7 +6,7 @@
     <Description>Trivial micro-orm implemented on Dapper, provides with CRUD helpers.</Description>
     <Authors>Sam Saffron</Authors>
     <Copyright>2017 Sam Saffron</Copyright>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;net5.0</TargetFrameworks>
     <!-- TODO: Docs -->
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/Dapper.Rainbow/Database.cs
+++ b/Dapper.Rainbow/Database.cs
@@ -45,7 +45,7 @@ namespace Dapper
             {
                 get
                 {
-                    tableName = tableName ?? database.DetermineTableName<T>(likelyTableName);
+                    tableName ??= database.DetermineTableName<T>(likelyTableName);
                     return tableName;
                 }
             }
@@ -142,7 +142,9 @@ namespace Dapper
                     foreach (var prop in o.GetType().GetProperties(BindingFlags.Instance | BindingFlags.Public).Where(p => p.GetGetMethod(false) != null))
                     {
                         var attribs = prop.GetCustomAttributes(typeof(IgnorePropertyAttribute), true);
+#pragma warning disable IDE0019 // Use pattern matching - complex enough here
                         var attr = attribs.FirstOrDefault() as IgnorePropertyAttribute;
+#pragma warning restore IDE0019 // Use pattern matching
                         if (attr == null || (!attr.Value))
                         {
                             paramNames.Add(prop.Name);
@@ -478,6 +480,7 @@ namespace Dapper
                 _connection.Close();
                 _connection = null;
             }
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/Dapper.Rainbow/Snapshotter.cs
+++ b/Dapper.Rainbow/Snapshotter.cs
@@ -69,14 +69,14 @@ namespace Dapper
 
             private static T Clone(T myObject)
             {
-                cloner = cloner ?? GenerateCloner();
+                cloner ??= GenerateCloner();
                 return cloner(myObject);
             }
 
             private static DynamicParameters Diff(T original, T current)
             {
                 var dm = new DynamicParameters();
-                differ = differ ?? GenerateDiffer();
+                differ ??= GenerateDiffer();
                 foreach (var pair in differ(original, current))
                 {
                     dm.Add(pair.Name, pair.NewValue);
@@ -98,8 +98,8 @@ namespace Dapper
 
             private static bool AreEqual<U>(U first, U second)
             {
-                if (EqualityComparer<U>.Default.Equals(first, default(U)) && EqualityComparer<U>.Default.Equals(second, default(U))) return true;
-                if (EqualityComparer<U>.Default.Equals(first, default(U))) return false;
+                if (EqualityComparer<U>.Default.Equals(first, default) && EqualityComparer<U>.Default.Equals(second, default)) return true;
+                if (EqualityComparer<U>.Default.Equals(first, default)) return false;
                 return first.Equals(second);
             }
 
@@ -191,7 +191,7 @@ namespace Dapper
             private static Func<T, T> GenerateCloner()
             {
                 var dm = new DynamicMethod("DoClone", typeof(T), new Type[] { typeof(T) }, true);
-                var ctor = typeof(T).GetConstructor(new Type[] { });
+                var ctor = typeof(T).GetConstructor(Type.EmptyTypes);
 
                 var il = dm.GetILGenerator();
 

--- a/Dapper.SqlBuilder/Dapper.SqlBuilder.csproj
+++ b/Dapper.SqlBuilder/Dapper.SqlBuilder.csproj
@@ -5,7 +5,7 @@
     <Title>Dapper SqlBuilder component</Title>
     <Description>The Dapper SqlBuilder component, for building SQL queries dynamically.</Description>
     <Authors>Sam Saffron, Johan Danforth</Authors>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;net5.0</TargetFrameworks>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/Dapper.StrongName/Dapper.StrongName.csproj
+++ b/Dapper.StrongName/Dapper.StrongName.csproj
@@ -5,9 +5,11 @@
     <Title>Dapper (Strong Named)</Title>
     <Description>A high performance Micro-ORM supporting SQL Server, MySQL, Sqlite, SqlCE, Firebird etc..</Description>
     <Authors>Sam Saffron;Marc Gravell;Nick Craver</Authors>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;net5.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+
+    <DefineConstants Condition=" '$(TargetFramework)' == 'net5.0'">$(DefineConstants);PLAT_NO_REMOTING</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Dapper\**\*.cs" Exclude="..\Dapper\obj\**\*.cs" />

--- a/Dapper.StrongName/Dapper.StrongName.csproj
+++ b/Dapper.StrongName/Dapper.StrongName.csproj
@@ -8,13 +8,16 @@
     <TargetFrameworks>net461;netstandard2.0;net5.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
-
-    <DefineConstants Condition=" '$(TargetFramework)' == 'net5.0'">$(DefineConstants);PLAT_NO_REMOTING</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
+    <Folder Include="Properties\" />
     <Compile Include="..\Dapper\**\*.cs" Exclude="..\Dapper\obj\**\*.cs" />
   </ItemGroup>
 
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net5.0'">
+    <DefineConstants>$(DefineConstants);PLAT_NO_REMOTING;PLAT_SKIP_LOCALS_INIT</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
   </ItemGroup>

--- a/Dapper.sln
+++ b/Dapper.sln
@@ -39,6 +39,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{4E956F6B-6BD
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{568BD46C-1C65-4D44-870C-12CD72563262}"
+	ProjectSection(SolutionItems) = preProject
+		tests\Directory.Build.props = tests\Directory.Build.props
+		tests\Directory.Build.targets = tests\Directory.Build.targets
+		tests\docker-compose.yml = tests\docker-compose.yml
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Dapper.EntityFramework.StrongName", "Dapper.EntityFramework.StrongName\Dapper.EntityFramework.StrongName.csproj", "{39D3EEB6-9C05-4F4A-8C01-7B209742A7EB}"
 EndProject

--- a/Dapper/CommandDefinition.cs
+++ b/Dapper/CommandDefinition.cs
@@ -19,7 +19,7 @@ namespace Dapper
             }
             else
             {
-                return default(CommandDefinition);
+                return default;
             }
         }
 
@@ -85,7 +85,7 @@ namespace Dapper
         /// <param name="cancellationToken">The cancellation token for this command.</param>
         public CommandDefinition(string commandText, object parameters = null, IDbTransaction transaction = null, int? commandTimeout = null,
                                  CommandType? commandType = null, CommandFlags flags = CommandFlags.Buffered
-                                 , CancellationToken cancellationToken = default(CancellationToken)
+                                 , CancellationToken cancellationToken = default
             )
         {
             CommandText = commandText;

--- a/Dapper/Dapper.csproj
+++ b/Dapper/Dapper.csproj
@@ -5,7 +5,8 @@
     <PackageTags>orm;sql;micro-orm</PackageTags>
     <Description>A high performance Micro-ORM supporting SQL Server, MySQL, Sqlite, SqlCE, Firebird etc..</Description>
     <Authors>Sam Saffron;Marc Gravell;Nick Craver</Authors>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;net5.0</TargetFrameworks>
+    <DefineConstants Condition=" '$(TargetFramework)' == 'net5.0'">$(DefineConstants);PLAT_NO_REMOTING</DefineConstants>
   </PropertyGroup>
   
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">

--- a/Dapper/Dapper.csproj
+++ b/Dapper/Dapper.csproj
@@ -6,9 +6,15 @@
     <Description>A high performance Micro-ORM supporting SQL Server, MySQL, Sqlite, SqlCE, Firebird etc..</Description>
     <Authors>Sam Saffron;Marc Gravell;Nick Craver</Authors>
     <TargetFrameworks>net461;netstandard2.0;net5.0</TargetFrameworks>
-    <DefineConstants Condition=" '$(TargetFramework)' == 'net5.0'">$(DefineConstants);PLAT_NO_REMOTING</DefineConstants>
   </PropertyGroup>
-  
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net5.0'">
+    <DefineConstants>$(DefineConstants);PLAT_NO_REMOTING;PLAT_SKIP_LOCALS_INIT</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
   </ItemGroup>

--- a/Dapper/DynamicParameters.cs
+++ b/Dapper/DynamicParameters.cs
@@ -373,9 +373,12 @@ namespace Dapper
                 names.Insert(0, diving?.Member.Name);
                 chain.Insert(0, diving);
 
+#pragma warning disable IDE0019 // use pattern matching; this is fine!
+                var constant = diving?.Expression as ParameterExpression;
                 diving = diving?.Expression as MemberExpression;
+#pragma warning restore IDE0019 // use pattern matching
 
-                if (diving?.Expression is ParameterExpression constant && constant.Type == typeof(T))
+                if (constant is object && constant.Type == typeof(T))
                 {
                     break;
                 }

--- a/Dapper/DynamicParameters.cs
+++ b/Dapper/DynamicParameters.cs
@@ -49,24 +49,7 @@ namespace Dapper
             var obj = param;
             if (obj != null)
             {
-                var subDynamic = obj as DynamicParameters;
-                if (subDynamic == null)
-                {
-                    var dictionary = obj as IEnumerable<KeyValuePair<string, object>>;
-                    if (dictionary == null)
-                    {
-                        templates ??= new List<object>();
-                        templates.Add(obj);
-                    }
-                    else
-                    {
-                        foreach (var kvp in dictionary)
-                        {
-                            Add(kvp.Key, kvp.Value, null, null, null);
-                        }
-                    }
-                }
-                else
+                if (obj is DynamicParameters subDynamic)
                 {
                     if (subDynamic.parameters != null)
                     {
@@ -83,6 +66,21 @@ namespace Dapper
                         {
                             templates.Add(t);
                         }
+                    }
+                }
+                else
+                {
+                    if (obj is IEnumerable<KeyValuePair<string, object>> dictionary)
+                    {
+                        foreach (var kvp in dictionary)
+                        {
+                            Add(kvp.Key, kvp.Value, null, null, null);
+                        }
+                    }
+                    else
+                    {
+                        templates ??= new List<object>();
+                        templates.Add(obj);
                     }
                 }
             }
@@ -320,7 +318,7 @@ namespace Dapper
                 {
                     throw new ApplicationException("Attempting to cast a DBNull to a non nullable type! Note that out/return parameters will not have updated values until the data stream completes (after the 'foreach' for Query(..., buffered: false), or after the GridReader has been disposed for QueryMultiple)");
                 }
-                return default(T);
+                return default;
             }
             return (T)val;
         }
@@ -337,12 +335,13 @@ namespace Dapper
         /// <returns>The DynamicParameters instance</returns>
         public DynamicParameters Output<T>(T target, Expression<Func<T, object>> expression, DbType? dbType = null, int? size = null)
         {
-            var failMessage = "Expression must be a property/field chain off of a(n) {0} instance";
-            failMessage = string.Format(failMessage, typeof(T).Name);
-            Action @throw = () => throw new InvalidOperationException(failMessage);
+            static void ThrowInvalidChain()
+                => throw new InvalidOperationException($"Expression must be a property/field chain off of a(n) {typeof(T).Name} instance");
 
             // Is it even a MemberExpression?
+#pragma warning disable IDE0019 // Use pattern matching - already complex enough
             var lastMemberAccess = expression.Body as MemberExpression;
+#pragma warning restore IDE0019 // Use pattern matching
 
             if (lastMemberAccess == null
                 || (!(lastMemberAccess.Member is PropertyInfo)
@@ -350,14 +349,14 @@ namespace Dapper
             {
                 if (expression.Body.NodeType == ExpressionType.Convert
                     && expression.Body.Type == typeof(object)
-                    && ((UnaryExpression)expression.Body).Operand is MemberExpression)
+                    && ((UnaryExpression)expression.Body).Operand is MemberExpression member)
                 {
                     // It's got to be unboxed
-                    lastMemberAccess = (MemberExpression)((UnaryExpression)expression.Body).Operand;
+                    lastMemberAccess = member;
                 }
                 else
                 {
-                    @throw();
+                    ThrowInvalidChain();
                 }
             }
 
@@ -374,10 +373,9 @@ namespace Dapper
                 names.Insert(0, diving?.Member.Name);
                 chain.Insert(0, diving);
 
-                var constant = diving?.Expression as ParameterExpression;
                 diving = diving?.Expression as MemberExpression;
 
-                if (constant != null && constant.Type == typeof(T))
+                if (diving?.Expression is ParameterExpression constant && constant.Type == typeof(T))
                 {
                     break;
                 }
@@ -385,7 +383,7 @@ namespace Dapper
                     || (!(diving.Member is PropertyInfo)
                         && !(diving.Member is FieldInfo)))
                 {
-                    @throw();
+                    ThrowInvalidChain();
                 }
             }
             while (diving != null);
@@ -430,9 +428,9 @@ namespace Dapper
 
             // GET READY
             var lastMember = lastMemberAccess.Member;
-            if (lastMember is PropertyInfo)
+            if (lastMember is PropertyInfo property)
             {
-                var set = ((PropertyInfo)lastMember).GetSetMethod(true);
+                var set = property.GetSetMethod(true);
                 il.Emit(OpCodes.Callvirt, set); // SET
             }
             else

--- a/Dapper/Properties/AssemblyInfo.cs
+++ b/Dapper/Properties/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+﻿
+#if PLAT_SKIP_LOCALS_INIT
+[module: System.Runtime.CompilerServices.SkipLocalsInit]
+#endif

--- a/Dapper/SqlMapper.Async.cs
+++ b/Dapper/SqlMapper.Async.cs
@@ -23,7 +23,7 @@ namespace Dapper
         /// <param name="commandType">The type of command to execute.</param>
         /// <remarks>Note: each row can be accessed via "dynamic", or by casting to an IDictionary&lt;string,object&gt;</remarks>
         public static Task<IEnumerable<dynamic>> QueryAsync(this IDbConnection cnn, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
-            QueryAsync<dynamic>(cnn, typeof(DapperRow), new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.Buffered, default(CancellationToken)));
+            QueryAsync<dynamic>(cnn, typeof(DapperRow), new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.Buffered, default));
 
         /// <summary>
         /// Execute a query asynchronously using Task.
@@ -85,7 +85,7 @@ namespace Dapper
         /// created per row, and a direct column-name===member-name mapping is assumed (case insensitive).
         /// </returns>
         public static Task<IEnumerable<T>> QueryAsync<T>(this IDbConnection cnn, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
-            QueryAsync<T>(cnn, typeof(T), new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.Buffered, default(CancellationToken)));
+            QueryAsync<T>(cnn, typeof(T), new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.Buffered, default));
 
         /// <summary>
         /// Execute a single-row query asynchronously using Task.
@@ -98,7 +98,7 @@ namespace Dapper
         /// <param name="commandTimeout">The command timeout (in seconds).</param>
         /// <param name="commandType">The type of command to execute.</param>
         public static Task<T> QueryFirstAsync<T>(this IDbConnection cnn, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
-            QueryRowAsync<T>(cnn, Row.First, typeof(T), new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.None, default(CancellationToken)));
+            QueryRowAsync<T>(cnn, Row.First, typeof(T), new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.None, default));
 
         /// <summary>
         /// Execute a single-row query asynchronously using Task.
@@ -111,7 +111,7 @@ namespace Dapper
         /// <param name="commandTimeout">The command timeout (in seconds).</param>
         /// <param name="commandType">The type of command to execute.</param>
         public static Task<T> QueryFirstOrDefaultAsync<T>(this IDbConnection cnn, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
-            QueryRowAsync<T>(cnn, Row.FirstOrDefault, typeof(T), new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.None, default(CancellationToken)));
+            QueryRowAsync<T>(cnn, Row.FirstOrDefault, typeof(T), new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.None, default));
 
         /// <summary>
         /// Execute a single-row query asynchronously using Task.
@@ -124,7 +124,7 @@ namespace Dapper
         /// <param name="commandTimeout">The command timeout (in seconds).</param>
         /// <param name="commandType">The type of command to execute.</param>
         public static Task<T> QuerySingleAsync<T>(this IDbConnection cnn, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
-            QueryRowAsync<T>(cnn, Row.Single, typeof(T), new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.None, default(CancellationToken)));
+            QueryRowAsync<T>(cnn, Row.Single, typeof(T), new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.None, default));
 
         /// <summary>
         /// Execute a single-row query asynchronously using Task.
@@ -137,7 +137,7 @@ namespace Dapper
         /// <param name="commandTimeout">The command timeout (in seconds).</param>
         /// <param name="commandType">The type of command to execute.</param>
         public static Task<T> QuerySingleOrDefaultAsync<T>(this IDbConnection cnn, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
-            QueryRowAsync<T>(cnn, Row.SingleOrDefault, typeof(T), new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.None, default(CancellationToken)));
+            QueryRowAsync<T>(cnn, Row.SingleOrDefault, typeof(T), new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.None, default));
 
         /// <summary>
         /// Execute a single-row query asynchronously using Task.
@@ -149,7 +149,7 @@ namespace Dapper
         /// <param name="commandTimeout">The command timeout (in seconds).</param>
         /// <param name="commandType">The type of command to execute.</param>
         public static Task<dynamic> QueryFirstAsync(this IDbConnection cnn, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
-            QueryRowAsync<dynamic>(cnn, Row.First, typeof(DapperRow), new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.None, default(CancellationToken)));
+            QueryRowAsync<dynamic>(cnn, Row.First, typeof(DapperRow), new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.None, default));
 
         /// <summary>
         /// Execute a single-row query asynchronously using Task.
@@ -161,7 +161,7 @@ namespace Dapper
         /// <param name="commandTimeout">The command timeout (in seconds).</param>
         /// <param name="commandType">The type of command to execute.</param>
         public static Task<dynamic> QueryFirstOrDefaultAsync(this IDbConnection cnn, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
-            QueryRowAsync<dynamic>(cnn, Row.FirstOrDefault, typeof(DapperRow), new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.None, default(CancellationToken)));
+            QueryRowAsync<dynamic>(cnn, Row.FirstOrDefault, typeof(DapperRow), new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.None, default));
 
         /// <summary>
         /// Execute a single-row query asynchronously using Task.
@@ -173,7 +173,7 @@ namespace Dapper
         /// <param name="commandTimeout">The command timeout (in seconds).</param>
         /// <param name="commandType">The type of command to execute.</param>
         public static Task<dynamic> QuerySingleAsync(this IDbConnection cnn, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
-            QueryRowAsync<dynamic>(cnn, Row.Single, typeof(DapperRow), new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.None, default(CancellationToken)));
+            QueryRowAsync<dynamic>(cnn, Row.Single, typeof(DapperRow), new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.None, default));
 
         /// <summary>
         /// Execute a single-row query asynchronously using Task.
@@ -185,7 +185,7 @@ namespace Dapper
         /// <param name="commandTimeout">The command timeout (in seconds).</param>
         /// <param name="commandType">The type of command to execute.</param>
         public static Task<dynamic> QuerySingleOrDefaultAsync(this IDbConnection cnn, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
-            QueryRowAsync<dynamic>(cnn, Row.SingleOrDefault, typeof(DapperRow), new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.None, default(CancellationToken)));
+            QueryRowAsync<dynamic>(cnn, Row.SingleOrDefault, typeof(DapperRow), new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.None, default));
 
         /// <summary>
         /// Execute a query asynchronously using Task.
@@ -201,7 +201,7 @@ namespace Dapper
         public static Task<IEnumerable<object>> QueryAsync(this IDbConnection cnn, Type type, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null)
         {
             if (type == null) throw new ArgumentNullException(nameof(type));
-            return QueryAsync<object>(cnn, type, new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.Buffered, default(CancellationToken)));
+            return QueryAsync<object>(cnn, type, new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.Buffered, default));
         }
 
         /// <summary>
@@ -218,7 +218,7 @@ namespace Dapper
         public static Task<object> QueryFirstAsync(this IDbConnection cnn, Type type, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null)
         {
             if (type == null) throw new ArgumentNullException(nameof(type));
-            return QueryRowAsync<object>(cnn, Row.First, type, new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.None, default(CancellationToken)));
+            return QueryRowAsync<object>(cnn, Row.First, type, new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.None, default));
         }
         /// <summary>
         /// Execute a single-row query asynchronously using Task.
@@ -234,7 +234,7 @@ namespace Dapper
         public static Task<object> QueryFirstOrDefaultAsync(this IDbConnection cnn, Type type, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null)
         {
             if (type == null) throw new ArgumentNullException(nameof(type));
-            return QueryRowAsync<object>(cnn, Row.FirstOrDefault, type, new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.None, default(CancellationToken)));
+            return QueryRowAsync<object>(cnn, Row.FirstOrDefault, type, new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.None, default));
         }
         /// <summary>
         /// Execute a single-row query asynchronously using Task.
@@ -250,7 +250,7 @@ namespace Dapper
         public static Task<object> QuerySingleAsync(this IDbConnection cnn, Type type, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null)
         {
             if (type == null) throw new ArgumentNullException(nameof(type));
-            return QueryRowAsync<object>(cnn, Row.Single, type, new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.None, default(CancellationToken)));
+            return QueryRowAsync<object>(cnn, Row.Single, type, new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.None, default));
         }
         /// <summary>
         /// Execute a single-row query asynchronously using Task.
@@ -266,7 +266,7 @@ namespace Dapper
         public static Task<object> QuerySingleOrDefaultAsync(this IDbConnection cnn, Type type, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null)
         {
             if (type == null) throw new ArgumentNullException(nameof(type));
-            return QueryRowAsync<object>(cnn, Row.SingleOrDefault, type, new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.None, default(CancellationToken)));
+            return QueryRowAsync<object>(cnn, Row.SingleOrDefault, type, new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.None, default));
         }
 
         /// <summary>
@@ -410,53 +410,51 @@ namespace Dapper
             var info = GetCacheInfo(identity, param, command.AddToCache);
             bool wasClosed = cnn.State == ConnectionState.Closed;
             var cancel = command.CancellationToken;
-            using (var cmd = command.TrySetupAsyncCommand(cnn, info.ParamReader))
+            using var cmd = command.TrySetupAsyncCommand(cnn, info.ParamReader);
+            DbDataReader reader = null;
+            try
             {
-                DbDataReader reader = null;
-                try
+                if (wasClosed) await cnn.TryOpenAsync(cancel).ConfigureAwait(false);
+                reader = await ExecuteReaderWithFlagsFallbackAsync(cmd, wasClosed, CommandBehavior.SequentialAccess | CommandBehavior.SingleResult, cancel).ConfigureAwait(false);
+
+                var tuple = info.Deserializer;
+                int hash = GetColumnHash(reader);
+                if (tuple.Func == null || tuple.Hash != hash)
                 {
-                    if (wasClosed) await cnn.TryOpenAsync(cancel).ConfigureAwait(false);
-                    reader = await ExecuteReaderWithFlagsFallbackAsync(cmd, wasClosed, CommandBehavior.SequentialAccess | CommandBehavior.SingleResult, cancel).ConfigureAwait(false);
-
-                    var tuple = info.Deserializer;
-                    int hash = GetColumnHash(reader);
-                    if (tuple.Func == null || tuple.Hash != hash)
-                    {
-                        if (reader.FieldCount == 0)
-                            return Enumerable.Empty<T>();
-                        tuple = info.Deserializer = new DeserializerState(hash, GetDeserializer(effectiveType, reader, 0, -1, false));
-                        if (command.AddToCache) SetQueryCache(identity, info);
-                    }
-
-                    var func = tuple.Func;
-
-                    if (command.Buffered)
-                    {
-                        var buffer = new List<T>();
-                        var convertToType = Nullable.GetUnderlyingType(effectiveType) ?? effectiveType;
-                        while (await reader.ReadAsync(cancel).ConfigureAwait(false))
-                        {
-                            object val = func(reader);
-                            buffer.Add(GetValue<T>(reader, effectiveType, val));
-                        }
-                        while (await reader.NextResultAsync(cancel).ConfigureAwait(false)) { /* ignore subsequent result sets */ }
-                        command.OnCompleted();
-                        return buffer;
-                    }
-                    else
-                    {
-                        // can't use ReadAsync / cancellation; but this will have to do
-                        wasClosed = false; // don't close if handing back an open reader; rely on the command-behavior
-                        var deferred = ExecuteReaderSync<T>(reader, func, command.Parameters);
-                        reader = null; // to prevent it being disposed before the caller gets to see it
-                        return deferred;
-                    }
+                    if (reader.FieldCount == 0)
+                        return Enumerable.Empty<T>();
+                    tuple = info.Deserializer = new DeserializerState(hash, GetDeserializer(effectiveType, reader, 0, -1, false));
+                    if (command.AddToCache) SetQueryCache(identity, info);
                 }
-                finally
+
+                var func = tuple.Func;
+
+                if (command.Buffered)
                 {
-                    using (reader) { /* dispose if non-null */ }
-                    if (wasClosed) cnn.Close();
+                    var buffer = new List<T>();
+                    var convertToType = Nullable.GetUnderlyingType(effectiveType) ?? effectiveType;
+                    while (await reader.ReadAsync(cancel).ConfigureAwait(false))
+                    {
+                        object val = func(reader);
+                        buffer.Add(GetValue<T>(reader, effectiveType, val));
+                    }
+                    while (await reader.NextResultAsync(cancel).ConfigureAwait(false)) { /* ignore subsequent result sets */ }
+                    command.OnCompleted();
+                    return buffer;
                 }
+                else
+                {
+                    // can't use ReadAsync / cancellation; but this will have to do
+                    wasClosed = false; // don't close if handing back an open reader; rely on the command-behavior
+                    var deferred = ExecuteReaderSync<T>(reader, func, command.Parameters);
+                    reader = null; // to prevent it being disposed before the caller gets to see it
+                    return deferred;
+                }
+            }
+            finally
+            {
+                using (reader) { /* dispose if non-null */ }
+                if (wasClosed) cnn.Close();
             }
         }
 
@@ -467,36 +465,34 @@ namespace Dapper
             var info = GetCacheInfo(identity, param, command.AddToCache);
             bool wasClosed = cnn.State == ConnectionState.Closed;
             var cancel = command.CancellationToken;
-            using (var cmd = command.TrySetupAsyncCommand(cnn, info.ParamReader))
+            using var cmd = command.TrySetupAsyncCommand(cnn, info.ParamReader);
+            DbDataReader reader = null;
+            try
             {
-                DbDataReader reader = null;
-                try
-                {
-                    if (wasClosed) await cnn.TryOpenAsync(cancel).ConfigureAwait(false);
-                    reader = await ExecuteReaderWithFlagsFallbackAsync(cmd, wasClosed, (row & Row.Single) != 0
-                    ? CommandBehavior.SequentialAccess | CommandBehavior.SingleResult // need to allow multiple rows, to check fail condition
-                    : CommandBehavior.SequentialAccess | CommandBehavior.SingleResult | CommandBehavior.SingleRow, cancel).ConfigureAwait(false);
+                if (wasClosed) await cnn.TryOpenAsync(cancel).ConfigureAwait(false);
+                reader = await ExecuteReaderWithFlagsFallbackAsync(cmd, wasClosed, (row & Row.Single) != 0
+                ? CommandBehavior.SequentialAccess | CommandBehavior.SingleResult // need to allow multiple rows, to check fail condition
+                : CommandBehavior.SequentialAccess | CommandBehavior.SingleResult | CommandBehavior.SingleRow, cancel).ConfigureAwait(false);
 
-                    T result = default;
-                    if (await reader.ReadAsync(cancel).ConfigureAwait(false) && reader.FieldCount != 0)
-                    {
-                        result = ReadRow<T>(info, identity, ref command, effectiveType, reader);
-
-                        if ((row & Row.Single) != 0 && await reader.ReadAsync(cancel).ConfigureAwait(false)) ThrowMultipleRows(row);
-                        while (await reader.ReadAsync(cancel).ConfigureAwait(false)) { /* ignore rows after the first */ }
-                    }
-                    else if ((row & Row.FirstOrDefault) == 0) // demanding a row, and don't have one
-                    {
-                        ThrowZeroRows(row);
-                    }
-                    while (await reader.NextResultAsync(cancel).ConfigureAwait(false)) { /* ignore result sets after the first */ }
-                    return result;
-                }
-                finally
+                T result = default;
+                if (await reader.ReadAsync(cancel).ConfigureAwait(false) && reader.FieldCount != 0)
                 {
-                    using (reader) { /* dispose if non-null */ }
-                    if (wasClosed) cnn.Close();
+                    result = ReadRow<T>(info, identity, ref command, effectiveType, reader);
+
+                    if ((row & Row.Single) != 0 && await reader.ReadAsync(cancel).ConfigureAwait(false)) ThrowMultipleRows(row);
+                    while (await reader.ReadAsync(cancel).ConfigureAwait(false)) { /* ignore rows after the first */ }
                 }
+                else if ((row & Row.FirstOrDefault) == 0) // demanding a row, and don't have one
+                {
+                    ThrowZeroRows(row);
+                }
+                while (await reader.NextResultAsync(cancel).ConfigureAwait(false)) { /* ignore result sets after the first */ }
+                return result;
+            }
+            finally
+            {
+                using (reader) { /* dispose if non-null */ }
+                if (wasClosed) cnn.Close();
             }
         }
 
@@ -511,7 +507,7 @@ namespace Dapper
         /// <param name="commandType">Is it a stored proc or a batch?</param>
         /// <returns>The number of rows affected.</returns>
         public static Task<int> ExecuteAsync(this IDbConnection cnn, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
-            ExecuteAsync(cnn, new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.Buffered, default(CancellationToken)));
+            ExecuteAsync(cnn, new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.Buffered, default));
 
         /// <summary>
         /// Execute a command asynchronously using Task.
@@ -609,25 +605,23 @@ namespace Dapper
                 }
                 else
                 {
-                    using (var cmd = command.TrySetupAsyncCommand(cnn, null))
+                    using var cmd = command.TrySetupAsyncCommand(cnn, null);
+                    foreach (var obj in multiExec)
                     {
-                        foreach (var obj in multiExec)
+                        if (isFirst)
                         {
-                            if (isFirst)
-                            {
-                                masterSql = cmd.CommandText;
-                                isFirst = false;
-                                var identity = new Identity(command.CommandText, cmd.CommandType, cnn, null, obj.GetType());
-                                info = GetCacheInfo(identity, obj, command.AddToCache);
-                            }
-                            else
-                            {
-                                cmd.CommandText = masterSql; // because we do magic replaces on "in" etc
-                                cmd.Parameters.Clear(); // current code is Add-tastic
-                            }
-                            info.ParamReader(cmd, obj);
-                            total += await cmd.ExecuteNonQueryAsync(command.CancellationToken).ConfigureAwait(false);
+                            masterSql = cmd.CommandText;
+                            isFirst = false;
+                            var identity = new Identity(command.CommandText, cmd.CommandType, cnn, null, obj.GetType());
+                            info = GetCacheInfo(identity, obj, command.AddToCache);
                         }
+                        else
+                        {
+                            cmd.CommandText = masterSql; // because we do magic replaces on "in" etc
+                            cmd.Parameters.Clear(); // current code is Add-tastic
+                        }
+                        info.ParamReader(cmd, obj);
+                        total += await cmd.ExecuteNonQueryAsync(command.CancellationToken).ConfigureAwait(false);
                     }
                 }
 
@@ -645,19 +639,17 @@ namespace Dapper
             var identity = new Identity(command.CommandText, command.CommandType, cnn, null, param?.GetType());
             var info = GetCacheInfo(identity, param, command.AddToCache);
             bool wasClosed = cnn.State == ConnectionState.Closed;
-            using (var cmd = command.TrySetupAsyncCommand(cnn, info.ParamReader))
+            using var cmd = command.TrySetupAsyncCommand(cnn, info.ParamReader);
+            try
             {
-                try
-                {
-                    if (wasClosed) await cnn.TryOpenAsync(command.CancellationToken).ConfigureAwait(false);
-                    var result = await cmd.ExecuteNonQueryAsync(command.CancellationToken).ConfigureAwait(false);
-                    command.OnCompleted();
-                    return result;
-                }
-                finally
-                {
-                    if (wasClosed) cnn.Close();
-                }
+                if (wasClosed) await cnn.TryOpenAsync(command.CancellationToken).ConfigureAwait(false);
+                var result = await cmd.ExecuteNonQueryAsync(command.CancellationToken).ConfigureAwait(false);
+                command.OnCompleted();
+                return result;
+            }
+            finally
+            {
+                if (wasClosed) cnn.Close();
             }
         }
 
@@ -680,7 +672,7 @@ namespace Dapper
         /// <returns>An enumerable of <typeparamref name="TReturn"/>.</returns>
         public static Task<IEnumerable<TReturn>> QueryAsync<TFirst, TSecond, TReturn>(this IDbConnection cnn, string sql, Func<TFirst, TSecond, TReturn> map, object param = null, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null) =>
             MultiMapAsync<TFirst, TSecond, DontMap, DontMap, DontMap, DontMap, DontMap, TReturn>(cnn,
-                new CommandDefinition(sql, param, transaction, commandTimeout, commandType, buffered ? CommandFlags.Buffered : CommandFlags.None, default(CancellationToken)), map, splitOn);
+                new CommandDefinition(sql, param, transaction, commandTimeout, commandType, buffered ? CommandFlags.Buffered : CommandFlags.None, default), map, splitOn);
 
         /// <summary>
         /// Perform a asynchronous multi-mapping query with 2 input types.
@@ -717,7 +709,7 @@ namespace Dapper
         /// <returns>An enumerable of <typeparamref name="TReturn"/>.</returns>
         public static Task<IEnumerable<TReturn>> QueryAsync<TFirst, TSecond, TThird, TReturn>(this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TReturn> map, object param = null, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null) =>
             MultiMapAsync<TFirst, TSecond, TThird, DontMap, DontMap, DontMap, DontMap, TReturn>(cnn,
-                new CommandDefinition(sql, param, transaction, commandTimeout, commandType, buffered ? CommandFlags.Buffered : CommandFlags.None, default(CancellationToken)), map, splitOn);
+                new CommandDefinition(sql, param, transaction, commandTimeout, commandType, buffered ? CommandFlags.Buffered : CommandFlags.None, default), map, splitOn);
 
         /// <summary>
         /// Perform a asynchronous multi-mapping query with 3 input types.
@@ -756,7 +748,7 @@ namespace Dapper
         /// <returns>An enumerable of <typeparamref name="TReturn"/>.</returns>
         public static Task<IEnumerable<TReturn>> QueryAsync<TFirst, TSecond, TThird, TFourth, TReturn>(this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TFourth, TReturn> map, object param = null, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null) =>
             MultiMapAsync<TFirst, TSecond, TThird, TFourth, DontMap, DontMap, DontMap, TReturn>(cnn,
-                new CommandDefinition(sql, param, transaction, commandTimeout, commandType, buffered ? CommandFlags.Buffered : CommandFlags.None, default(CancellationToken)), map, splitOn);
+                new CommandDefinition(sql, param, transaction, commandTimeout, commandType, buffered ? CommandFlags.Buffered : CommandFlags.None, default), map, splitOn);
 
         /// <summary>
         /// Perform a asynchronous multi-mapping query with 4 input types.
@@ -797,7 +789,7 @@ namespace Dapper
         /// <returns>An enumerable of <typeparamref name="TReturn"/>.</returns>
         public static Task<IEnumerable<TReturn>> QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TReturn>(this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TFourth, TFifth, TReturn> map, object param = null, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null) =>
             MultiMapAsync<TFirst, TSecond, TThird, TFourth, TFifth, DontMap, DontMap, TReturn>(cnn,
-                new CommandDefinition(sql, param, transaction, commandTimeout, commandType, buffered ? CommandFlags.Buffered : CommandFlags.None, default(CancellationToken)), map, splitOn);
+                new CommandDefinition(sql, param, transaction, commandTimeout, commandType, buffered ? CommandFlags.Buffered : CommandFlags.None, default), map, splitOn);
 
         /// <summary>
         /// Perform a asynchronous multi-mapping query with 5 input types.
@@ -840,7 +832,7 @@ namespace Dapper
         /// <returns>An enumerable of <typeparamref name="TReturn"/>.</returns>
         public static Task<IEnumerable<TReturn>> QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TReturn>(this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TReturn> map, object param = null, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null) =>
             MultiMapAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, DontMap, TReturn>(cnn,
-                new CommandDefinition(sql, param, transaction, commandTimeout, commandType, buffered ? CommandFlags.Buffered : CommandFlags.None, default(CancellationToken)), map, splitOn);
+                new CommandDefinition(sql, param, transaction, commandTimeout, commandType, buffered ? CommandFlags.Buffered : CommandFlags.None, default), map, splitOn);
 
         /// <summary>
         /// Perform a asynchronous multi-mapping query with 6 input types.
@@ -885,7 +877,7 @@ namespace Dapper
         /// <returns>An enumerable of <typeparamref name="TReturn"/>.</returns>
         public static Task<IEnumerable<TReturn>> QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn> map, object param = null, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null) =>
             MultiMapAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(cnn,
-                new CommandDefinition(sql, param, transaction, commandTimeout, commandType, buffered ? CommandFlags.Buffered : CommandFlags.None, default(CancellationToken)), map, splitOn);
+                new CommandDefinition(sql, param, transaction, commandTimeout, commandType, buffered ? CommandFlags.Buffered : CommandFlags.None, default), map, splitOn);
 
         /// <summary>
         /// Perform an asynchronous multi-mapping query with 7 input types.
@@ -916,13 +908,11 @@ namespace Dapper
             try
             {
                 if (wasClosed) await cnn.TryOpenAsync(command.CancellationToken).ConfigureAwait(false);
-                using (var cmd = command.TrySetupAsyncCommand(cnn, info.ParamReader))
-                using (var reader = await ExecuteReaderWithFlagsFallbackAsync(cmd, wasClosed, CommandBehavior.SequentialAccess | CommandBehavior.SingleResult, command.CancellationToken).ConfigureAwait(false))
-                {
-                    if (!command.Buffered) wasClosed = false; // handing back open reader; rely on command-behavior
-                    var results = MultiMapImpl<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(null, CommandDefinition.ForCallback(command.Parameters), map, splitOn, reader, identity, true);
-                    return command.Buffered ? results.ToList() : results;
-                }
+                using var cmd = command.TrySetupAsyncCommand(cnn, info.ParamReader);
+                using var reader = await ExecuteReaderWithFlagsFallbackAsync(cmd, wasClosed, CommandBehavior.SequentialAccess | CommandBehavior.SingleResult, command.CancellationToken).ConfigureAwait(false);
+                if (!command.Buffered) wasClosed = false; // handing back open reader; rely on command-behavior
+                var results = MultiMapImpl<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(null, CommandDefinition.ForCallback(command.Parameters), map, splitOn, reader, identity, true);
+                return command.Buffered ? results.ToList() : results;
             }
             finally
             {
@@ -948,7 +938,7 @@ namespace Dapper
         /// <returns>An enumerable of <typeparamref name="TReturn"/>.</returns>
         public static Task<IEnumerable<TReturn>> QueryAsync<TReturn>(this IDbConnection cnn, string sql, Type[] types, Func<object[], TReturn> map, object param = null, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
         {
-            var command = new CommandDefinition(sql, param, transaction, commandTimeout, commandType, buffered ? CommandFlags.Buffered : CommandFlags.None, default(CancellationToken));
+            var command = new CommandDefinition(sql, param, transaction, commandTimeout, commandType, buffered ? CommandFlags.Buffered : CommandFlags.None, default);
             return MultiMapAsync(cnn, command, types, map, splitOn);
         }
 
@@ -966,12 +956,10 @@ namespace Dapper
             try
             {
                 if (wasClosed) await cnn.TryOpenAsync(command.CancellationToken).ConfigureAwait(false);
-                using (var cmd = command.TrySetupAsyncCommand(cnn, info.ParamReader))
-                using (var reader = await ExecuteReaderWithFlagsFallbackAsync(cmd, wasClosed, CommandBehavior.SequentialAccess | CommandBehavior.SingleResult, command.CancellationToken).ConfigureAwait(false))
-                {
-                    var results = MultiMapImpl(null, default(CommandDefinition), types, map, splitOn, reader, identity, true);
-                    return command.Buffered ? results.ToList() : results;
-                }
+                using var cmd = command.TrySetupAsyncCommand(cnn, info.ParamReader);
+                using var reader = await ExecuteReaderWithFlagsFallbackAsync(cmd, wasClosed, CommandBehavior.SequentialAccess | CommandBehavior.SingleResult, command.CancellationToken).ConfigureAwait(false);
+                var results = MultiMapImpl(null, default, types, map, splitOn, reader, identity, true);
+                return command.Buffered ? results.ToList() : results;
             }
             finally
             {

--- a/Dapper/SqlMapper.DapperRow.cs
+++ b/Dapper/SqlMapper.DapperRow.cs
@@ -76,7 +76,7 @@ namespace Dapper
                     }
                 }
 
-                return sb.Append('}').__ToStringRecycle();
+                return sb.Append('}').ToStringRecycle();
             }
 
             public IEnumerator<KeyValuePair<string, object>> GetEnumerator()

--- a/Dapper/SqlMapper.DapperRowMetaObject.cs
+++ b/Dapper/SqlMapper.DapperRowMetaObject.cs
@@ -89,11 +89,10 @@ namespace Dapper
                 return callMethod;
             }
 
-            static readonly string[] s_nixKeys = new string[0];
             public override IEnumerable<string> GetDynamicMemberNames()
             {
                 if(HasValue && Value is IDictionary<string, object> lookup) return lookup.Keys;
-                return s_nixKeys;
+                return Array.Empty<string>();
             }
         }
     }

--- a/Dapper/SqlMapper.GridReader.Async.cs
+++ b/Dapper/SqlMapper.GridReader.Async.cs
@@ -141,7 +141,7 @@ namespace Dapper
             {
                 if (await ((DbDataReader)reader).NextResultAsync(cancel).ConfigureAwait(false))
                 {
-                    readCount++;
+                    // readCount++;
                     gridIndex++;
                     IsConsumed = false;
                 }
@@ -197,7 +197,7 @@ namespace Dapper
                 if (IsConsumed) throw new InvalidOperationException("Query results must be consumed in the correct order, and each result can only be consumed once");
 
                 IsConsumed = true;
-                T result = default(T);
+                T result = default;
                 if (await reader.ReadAsync(cancel).ConfigureAwait(false) && reader.FieldCount != 0)
                 {
                     var typedIdentity = identity.ForGrid(type, gridIndex);

--- a/Dapper/SqlMapper.GridReader.cs
+++ b/Dapper/SqlMapper.GridReader.cs
@@ -168,7 +168,7 @@ namespace Dapper
                 if (IsConsumed) throw new InvalidOperationException("Query results must be consumed in the correct order, and each result can only be consumed once");
                 IsConsumed = true;
 
-                T result = default(T);
+                T result = default;
                 if (reader.Read() && reader.FieldCount != 0)
                 {
                     var typedIdentity = identity.ForGrid(type, gridIndex);
@@ -210,7 +210,7 @@ namespace Dapper
 
                 try
                 {
-                    foreach (var r in MultiMapImpl<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(null, default(CommandDefinition), func, splitOn, reader, identity, false))
+                    foreach (var r in MultiMapImpl<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(null, default, func, splitOn, reader, identity, false))
                     {
                         yield return r;
                     }
@@ -226,7 +226,7 @@ namespace Dapper
                 var identity = this.identity.ForGrid(typeof(TReturn), types, gridIndex);
                 try
                 {
-                    foreach (var r in MultiMapImpl<TReturn>(null, default(CommandDefinition), types, map, splitOn, reader, identity, false))
+                    foreach (var r in MultiMapImpl<TReturn>(null, default, types, map, splitOn, reader, identity, false))
                     {
                         yield return r;
                     }
@@ -383,7 +383,7 @@ namespace Dapper
                 }
             }
 
-            private int gridIndex, readCount;
+            private int gridIndex; //, readCount;
             private readonly IParameterCallbacks callbacks;
 
             /// <summary>
@@ -400,7 +400,7 @@ namespace Dapper
             {
                 if (reader.NextResult())
                 {
-                    readCount++;
+                    // readCount++;
                     gridIndex++;
                     IsConsumed = false;
                 }
@@ -431,6 +431,7 @@ namespace Dapper
                     Command.Dispose();
                     Command = null;
                 }
+                GC.SuppressFinalize(this);
             }
         }
     }

--- a/Dapper/SqlMapper.IDataReader.cs
+++ b/Dapper/SqlMapper.IDataReader.cs
@@ -138,7 +138,7 @@ namespace Dapper
         public static Func<IDataReader, T> GetRowParser<T>(this IDataReader reader, Type concreteType = null,
             int startIndex = 0, int length = -1, bool returnNullIfFirstMissing = false)
         {
-            concreteType = concreteType ?? typeof(T);
+            concreteType ??= typeof(T);
             var func = GetDeserializer(concreteType, reader, startIndex, length, returnNullIfFirstMissing);
             if (concreteType.IsValueType)
             {

--- a/Dapper/SqlMapper.Identity.cs
+++ b/Dapper/SqlMapper.Identity.cs
@@ -39,20 +39,16 @@ namespace Dapper
                 return count;
             }
             internal override int TypeCount => s_typeCount;
-            internal override Type GetType(int index)
-            {
-                switch (index)
-                {
-                    case 0: return typeof(TFirst);
-                    case 1: return typeof(TSecond);
-                    case 2: return typeof(TThird);
-                    case 3: return typeof(TFourth);
-                    case 4: return typeof(TFifth);
-                    case 5: return typeof(TSixth);
-                    case 6: return typeof(TSeventh);
-                    default: return base.GetType(index);
-                }
-            }
+            internal override Type GetType(int index) => index switch {
+                0 => typeof(TFirst),
+                1 => typeof(TSecond),
+                2 => typeof(TThird),
+                3 => typeof(TFourth),
+                4 => typeof(TFifth),
+                5 => typeof(TSixth),
+                6 => typeof(TSeventh),
+                _ => base.GetType(index),
+            };
         }
         internal sealed class IdentityWithTypes : Identity
         {
@@ -199,7 +195,7 @@ namespace Dapper
             public bool Equals(Identity other)
             {
                 if (ReferenceEquals(this, other)) return true;
-                if (ReferenceEquals(other, null)) return false;
+                if (other is null) return false;
 
                 int typeCount;
                 return gridIndex == other.gridIndex

--- a/Dapper/SqlMapper.Link.cs
+++ b/Dapper/SqlMapper.Link.cs
@@ -24,7 +24,7 @@ namespace Dapper
                     }
                     link = link.Tail;
                 }
-                value = default(TValue);
+                value = default;
                 return false;
             }
 

--- a/Dapper/SqlMapper.LiteralToken.cs
+++ b/Dapper/SqlMapper.LiteralToken.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Dapper
 {
@@ -25,7 +26,7 @@ namespace Dapper
                 Member = member;
             }
 
-            internal static readonly IList<LiteralToken> None = new LiteralToken[0];
+            internal static IList<LiteralToken> None => Array.Empty<LiteralToken>();
         }
     }
 }

--- a/Dapper/SqlMapper.TypeDeserializerCache.cs
+++ b/Dapper/SqlMapper.TypeDeserializerCache.cs
@@ -111,9 +111,7 @@ namespace Dapper
                 }
 
                 public override bool Equals(object obj)
-                {
-                    return obj is DeserializerKey && Equals((DeserializerKey)obj);
-                }
+                    => obj is DeserializerKey key && Equals(key);
 
                 public bool Equals(DeserializerKey other)
                 {

--- a/Dapper/SqlMapper.TypeHandler.cs
+++ b/Dapper/SqlMapper.TypeHandler.cs
@@ -78,7 +78,7 @@ namespace Dapper
             /// <returns>The typed value</returns>
             public override T Parse(object value)
             {
-                if (value == null || value is DBNull) return default(T);
+                if (value == null || value is DBNull) return default;
                 return Parse((string)value);
             }
         }

--- a/Dapper/WrappedReader.cs
+++ b/Dapper/WrappedReader.cs
@@ -31,6 +31,10 @@ namespace Dapper
         }
         public override void Close() { }
         public override DataTable GetSchemaTable() => ThrowDisposed<DataTable>();
+
+#if PLAT_NO_REMOTING
+        [Obsolete("This Remoting API is not supported and throws PlatformNotSupportedException.", DiagnosticId = "SYSLIB0010", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+#endif
         public override object InitializeLifetimeService() => ThrowDisposed<object>();
         protected override void Dispose(bool disposing) { }
         public override bool GetBoolean(int ordinal) => ThrowDisposed<bool>();
@@ -116,6 +120,10 @@ namespace Dapper
 
         public override void Close() => _reader.Close();
         public override DataTable GetSchemaTable() => _reader.GetSchemaTable();
+
+#if PLAT_NO_REMOTING
+        [Obsolete("This Remoting API is not supported and throws PlatformNotSupportedException.", DiagnosticId = "SYSLIB0010", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+#endif
         public override object InitializeLifetimeService() => _reader.InitializeLifetimeService();
 
         public override int Depth => _reader.Depth;

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,7 +21,7 @@
 
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/StackExchange/Dapper</RepositoryUrl>
     <Deterministic>false</Deterministic>
-    
+    <NoWarn>$(NOWARN);IDE0056;IDE0057;IDE0079</NoWarn>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>embedded</DebugType>
     <DefaultLanguage>en-US</DefaultLanguage>

--- a/benchmarks/Dapper.Tests.Performance/Benchmarks.EntityFrameworkCore.cs
+++ b/benchmarks/Dapper.Tests.Performance/Benchmarks.EntityFrameworkCore.cs
@@ -40,7 +40,7 @@ namespace Dapper.Tests.Performance
         public Post SqlQuery()
         {
             Step();
-            return Context.Posts.FromSql("select * from Posts where Id = {0}", i).First();
+            return Context.Posts.FromSqlRaw("select * from Posts where Id = {0}", i).First();
         }
 
         [Benchmark(Description = "First (No Tracking)")]

--- a/benchmarks/Dapper.Tests.Performance/Benchmarks.XPO.cs
+++ b/benchmarks/Dapper.Tests.Performance/Benchmarks.XPO.cs
@@ -19,8 +19,10 @@ namespace Dapper.Tests.Performance
             BaseSetup();
             IDataLayer dataLayer = XpoDefault.GetDataLayer(_connection, DevExpress.Xpo.DB.AutoCreateOption.SchemaAlreadyExists);
             dataLayer.Dictionary.GetDataStoreSchema(typeof(Xpo.Post));
-            _session = new UnitOfWork(dataLayer, dataLayer);
-            _session.IdentityMapBehavior = IdentityMapBehavior.Strong;
+            _session = new UnitOfWork(dataLayer, dataLayer)
+            {
+                IdentityMapBehavior = IdentityMapBehavior.Strong
+            };
             _session.TypesManager.EnsureIsTypedObjectValid();
         }
 

--- a/benchmarks/Dapper.Tests.Performance/Dapper.Tests.Performance.csproj
+++ b/benchmarks/Dapper.Tests.Performance/Dapper.Tests.Performance.csproj
@@ -5,26 +5,26 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net462;netcoreapp3.1</TargetFrameworks>
     <IsTestProject>false</IsTestProject>
+    <NoWarn>$(NoWarn);IDE0063</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Dashing" Version="2.2.0" />
+    <PackageReference Include="Dashing" Version="2.4.3" />
     <PackageReference Include="Belgrade.Sql.Client" Version="1.1.4" />
     <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
-    <PackageReference Include="DevExpress.Xpo" Version="19.1.5" />
+    <PackageReference Include="DevExpress.Xpo" Version="20.2.3" />
     <!--<PackageReference Include="BLToolkit" Version="4.3.6" />-->
-    <PackageReference Include="EntityFramework" Version="6.3.0" />
-    <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="7.0.0" />
-    <PackageReference Include="linq2db.SqlServer" Version="2.9.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.2.6" />
-    <PackageReference Include="MySqlConnector" Version="0.56.0" />
-    <PackageReference Include="NHibernate" Version="5.2.5" />
+    <PackageReference Include="EntityFramework" Version="6.4.4" />
+    <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="7.5.0" />
+    <PackageReference Include="linq2db.SqlServer" Version="3.1.6" />
+    <PackageReference Include="MySqlConnector" Version="1.1.0" />
+    <PackageReference Include="NHibernate" Version="5.3.5" />
     <PackageReference Include="Iesi.Collections" Version="4.0.4" />
-    <PackageReference Include="Mighty" Version="3.0.6" />
-    <PackageReference Include="Npgsql" Version="4.0.9" />
+    <PackageReference Include="Mighty" Version="3.1.3" />
+    <PackageReference Include="Npgsql" Version="5.0.0" />
     <PackageReference Include="PetaPoco" Version="5.1.306" />
-    <PackageReference Include="ServiceStack.OrmLite.SqlServer" Version="5.6.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.1" />
-    <PackageReference Include="System.Data.SQLite" Version="1.0.111" />
+    <PackageReference Include="ServiceStack.OrmLite.SqlServer" Version="5.10.2" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
+    <PackageReference Include="System.Data.SQLite" Version="1.0.113.6" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="NHibernate\*.xml" />
@@ -40,8 +40,12 @@
     <PackageReference Include="Soma" Version="1.9.0.1" />
     <PackageReference Include="SubSonic" Version="3.0.0.4" />
     <PackageReference Include="Susanoo.SqlServer" Version="1.2.4.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="[3.1.10]" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Data.Linq" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'net462'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.0" />
   </ItemGroup>
 </Project>

--- a/benchmarks/Dapper.Tests.Performance/Dapper.Tests.Performance.csproj
+++ b/benchmarks/Dapper.Tests.Performance/Dapper.Tests.Performance.csproj
@@ -5,7 +5,7 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net462;netcoreapp3.1</TargetFrameworks>
     <IsTestProject>false</IsTestProject>
-    <NoWarn>$(NoWarn);IDE0063</NoWarn>
+    <NoWarn>$(NoWarn);IDE0063;IDE0034;IDE0059;IDE0060</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Dashing" Version="2.4.3" />

--- a/benchmarks/Dapper.Tests.Performance/Dashing/DashingConfiguration.cs
+++ b/benchmarks/Dapper.Tests.Performance/Dashing/DashingConfiguration.cs
@@ -6,7 +6,7 @@ namespace Dapper.Tests.Performance.Dashing
     {
         public DashingConfiguration()
         {
-            this.Add<Post>();
+            Add<Post>();
         }
     }
 }

--- a/benchmarks/Dapper.Tests.Performance/LegacyTests.cs
+++ b/benchmarks/Dapper.Tests.Performance/LegacyTests.cs
@@ -143,7 +143,7 @@ namespace Dapper.Tests.Performance
                     tests.Add(id => entityContext.Posts.First(p => p.Id == id), "Entity Framework Core");
 
                     var entityContext2 = new EFCoreContext(ConnectionString);
-                    tests.Add(id => entityContext2.Posts.FromSql("select * from Posts where Id = {0}", id).First(), "Entity Framework Core: FromSql");
+                    tests.Add(id => entityContext2.Posts.FromSqlRaw("select * from Posts where Id = {0}", id).First(), "Entity Framework Core: FromSql");
 
                     var entityContext3 = new EFCoreContext(ConnectionString);
                     tests.Add(id => entityContext3.Posts.AsNoTracking().First(p => p.Id == id), "Entity Framework Core: No Tracking");

--- a/benchmarks/Dapper.Tests.Performance/Massive/Massive.cs
+++ b/benchmarks/Dapper.Tests.Performance/Massive/Massive.cs
@@ -115,9 +115,9 @@ namespace Massive
     {
         private readonly DbProviderFactory _factory;
 #pragma warning disable 0649
-#pragma warning disable RCS1169 // Mark field as read-only.
+#pragma warning disable RCS1169,IDE0044 // Mark field as read-only.
         private string _connectionString;
-#pragma warning restore RCS1169 // Mark field as read-only.
+#pragma warning restore RCS1169,IDE0044 // Mark field as read-only.
 #pragma warning restore 0649
 
         public DynamicModel(string connectionStringName = "", string tableName = "", string primaryKeyField = "")

--- a/benchmarks/Dapper.Tests.Performance/PetaPoco/PetaPoco.cs
+++ b/benchmarks/Dapper.Tests.Performance/PetaPoco/PetaPoco.cs
@@ -612,10 +612,12 @@ namespace PetaPoco
                 throw new Exception("Unable to parse SQL statement for paged query");
 
             // Setup the paged result
-            var result = new Page<T>();
-            result.CurrentPage = page;
-            result.ItemsPerPage = itemsPerPage;
-            result.TotalItems = ExecuteScalar<long>(sqlCount, args);
+            var result = new Page<T>
+            {
+                CurrentPage = page,
+                ItemsPerPage = itemsPerPage,
+                TotalItems = ExecuteScalar<long>(sqlCount, args)
+            };
             result.TotalPages = result.TotalItems / itemsPerPage;
             if ((result.TotalItems % itemsPerPage) != 0)
                 result.TotalPages++;
@@ -829,7 +831,7 @@ namespace PetaPoco
                             // Don't update the primary key, but grab the value if we don't have it
                             if (i.Key == primaryKeyName)
                             {
-                                primaryKeyValue = primaryKeyValue ?? i.Value.PropertyInfo.GetValue(poco, null);
+                                primaryKeyValue ??= i.Value.PropertyInfo.GetValue(poco, null);
                                 continue;
                             }
 

--- a/tests/Dapper.Tests.Contrib/Dapper.Tests.Contrib.csproj
+++ b/tests/Dapper.Tests.Contrib/Dapper.Tests.Contrib.csproj
@@ -2,7 +2,8 @@
   <PropertyGroup>
     <AssemblyName>Dapper.Tests.Contrib</AssemblyName>
     <Description>Dapper Contrib Test Suite</Description>
-    <TargetFrameworks>netcoreapp3.1;net462</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net462;net5.0</TargetFrameworks>
+    <NoWarn>$(NoWarn);IDE0063;xUnit1004</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="../Dapper.Tests/Helpers/XunitSkippable.cs" Link="Helpers/XunitSkippable.cs" />
@@ -10,9 +11,9 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../Dapper.SqlBuilder/Dapper.SqlBuilder.csproj" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="2.2.6" />
-    <PackageReference Include="MySqlConnector" Version="0.56.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.1" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="5.0.0" />
+    <PackageReference Include="MySqlConnector" Version="1.1.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <Reference Include="Microsoft.CSharp" />

--- a/tests/Dapper.Tests.Contrib/Dapper.Tests.Contrib.csproj
+++ b/tests/Dapper.Tests.Contrib/Dapper.Tests.Contrib.csproj
@@ -8,6 +8,10 @@
   <ItemGroup>
     <Compile Include="../Dapper.Tests/Helpers/XunitSkippable.cs" Link="Helpers/XunitSkippable.cs" />
     <None Remove="Test.DB.sdf" />
+
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../Dapper.SqlBuilder/Dapper.SqlBuilder.csproj" />

--- a/tests/Dapper.Tests.Contrib/Dapper.Tests.Contrib.csproj
+++ b/tests/Dapper.Tests.Contrib/Dapper.Tests.Contrib.csproj
@@ -3,7 +3,7 @@
     <AssemblyName>Dapper.Tests.Contrib</AssemblyName>
     <Description>Dapper Contrib Test Suite</Description>
     <TargetFrameworks>netcoreapp3.1;net462;net5.0</TargetFrameworks>
-    <NoWarn>$(NoWarn);IDE0063;xUnit1004</NoWarn>
+    <NoWarn>$(NoWarn);CA1816;IDE0063;xUnit1004</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="../Dapper.Tests/Helpers/XunitSkippable.cs" Link="Helpers/XunitSkippable.cs" />

--- a/tests/Dapper.Tests.Contrib/TestSuites.cs
+++ b/tests/Dapper.Tests.Contrib/TestSuites.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.Data.Sqlite;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using System;
 using System.Data;
 using System.Data.SqlClient;

--- a/tests/Dapper.Tests.Contrib/xunit.runner.json
+++ b/tests/Dapper.Tests.Contrib/xunit.runner.json
@@ -1,0 +1,4 @@
+﻿{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "shadowCopy": false
+}

--- a/tests/Dapper.Tests/AsyncTests.cs
+++ b/tests/Dapper.Tests/AsyncTests.cs
@@ -35,7 +35,7 @@ namespace Dapper.Tests
     {
         private DbConnection _marsConnection;
 
-        private DbConnection MarsConnection => _marsConnection ?? (_marsConnection = Provider.GetOpenConnection(true));
+        private DbConnection MarsConnection => _marsConnection ??= Provider.GetOpenConnection(true);
 
         [Fact]
         public async Task TestBasicStringUsageAsync()
@@ -323,7 +323,7 @@ namespace Dapper.Tests
             using (var conn = GetClosedConnection()) await LiteralReplacement(conn).ConfigureAwait(false);
         }
 
-        private async Task LiteralReplacement(IDbConnection conn)
+        private static async Task LiteralReplacement(IDbConnection conn)
         {
             try
             {
@@ -352,7 +352,7 @@ namespace Dapper.Tests
             using (var conn = GetClosedConnection()) await LiteralReplacementDynamic(conn).ConfigureAwait(false);
         }
 
-        private async Task LiteralReplacementDynamic(IDbConnection conn)
+        private static async Task LiteralReplacementDynamic(IDbConnection conn)
         {
             var args = new DynamicParameters();
             args.Add("id", 123);
@@ -841,7 +841,7 @@ SET @AddressPersonId = @PersonId", p).ConfigureAwait(false))
         private readonly ITestOutputHelper _log;
         public AsyncQueryCacheTests(ITestOutputHelper log) => _log = log;
         private DbConnection _marsConnection;
-        private DbConnection MarsConnection => _marsConnection ?? (_marsConnection = Provider.GetOpenConnection(true));
+        private DbConnection MarsConnection => _marsConnection ??= Provider.GetOpenConnection(true);
 
         public override void Dispose()
         {

--- a/tests/Dapper.Tests/Dapper.Tests.csproj
+++ b/tests/Dapper.Tests/Dapper.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyName>Dapper.Tests</AssemblyName>
     <Description>Dapper Core Test Suite</Description>
-    <TargetFrameworks>netcoreapp3.1;net462;net472</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net462;net472;net5.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);MSSQLCLIENT</DefineConstants>
   </PropertyGroup>
 

--- a/tests/Dapper.Tests/Dapper.Tests.csproj
+++ b/tests/Dapper.Tests/Dapper.Tests.csproj
@@ -4,7 +4,7 @@
     <Description>Dapper Core Test Suite</Description>
     <TargetFrameworks>netcoreapp3.1;net462;net472;net5.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);MSSQLCLIENT</DefineConstants>
-    <NoWarn>$(NoWarn);IDE0063;xUnit1004</NoWarn>
+    <NoWarn>$(NoWarn);IDE0017;IDE0034;IDE0037;IDE0039;IDE0042;IDE0044;IDE0051;IDE0052;IDE0059;IDE0060;IDE0063;IDE1006;xUnit1004;CA1806;CA1816;CA1822;CA1825;CA2208</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net472'">

--- a/tests/Dapper.Tests/Dapper.Tests.csproj
+++ b/tests/Dapper.Tests/Dapper.Tests.csproj
@@ -22,6 +22,8 @@
     <PackageReference Include="Npgsql" Version="5.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+
+
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net472'">
@@ -32,5 +34,9 @@
     <!-- Conditionals make the tooling go crazy...just include them for this test project -->
     <Content Include="$(NuGetPackageRoot)\microsoft.sqlserver.types\14.0.1016.290\nativeBinaries\**\*.dll" CopyToOutputDirectory="PreserveNewest" />
     <None Remove="Test.DB.sdf" />
+
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/tests/Dapper.Tests/Dapper.Tests.csproj
+++ b/tests/Dapper.Tests/Dapper.Tests.csproj
@@ -4,6 +4,7 @@
     <Description>Dapper Core Test Suite</Description>
     <TargetFrameworks>netcoreapp3.1;net462;net472;net5.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);MSSQLCLIENT</DefineConstants>
+    <NoWarn>$(NoWarn);IDE0063;xUnit1004</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net472'">
@@ -13,13 +14,13 @@
   <ItemGroup>
     <ProjectReference Include="../../Dapper.ProviderTools/Dapper.ProviderTools.csproj" />
     <ProjectReference Include="../../Dapper.SqlBuilder/Dapper.SqlBuilder.csproj" />
-    <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="2.2.6" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
-    <PackageReference Include="MySqlConnector" Version="0.56.0" />
-    <PackageReference Include="Npgsql" Version="4.0.9" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.1" />
+    <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="7.5.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="5.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="MySqlConnector" Version="1.1.0" />
+    <PackageReference Include="Npgsql" Version="5.0.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 

--- a/tests/Dapper.Tests/MiscTests.cs
+++ b/tests/Dapper.Tests/MiscTests.cs
@@ -1,14 +1,23 @@
-﻿using Microsoft.CSharp.RuntimeBinder;
-using System;
+﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Data;
 using System.Data.Common;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CSharp.RuntimeBinder;
 using Xunit;
+
+#if NETCOREAPP3_1 || NET462 || NET472
+namespace System.Runtime.CompilerServices
+{
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    internal static class IsExternalInit // yeah, don't do this!
+    {
+    }
+}
+#endif
 
 namespace Dapper.Tests
 {
@@ -56,15 +65,43 @@ namespace Dapper.Tests
         private struct CarWithAllProps
         {
             public string Name { get; set; }
-            public int Age { get; set; }
+            public int Age { get; init; }
+            public Car.TrapEnum Trap { get; init; }
+        }
 
-            public Car.TrapEnum Trap { get; set; }
+        private record PositionalCarRecord(string Name, int Age, Car.TrapEnum Trap);
+
+        private record NominalCarRecord
+        {
+            public string Name { get; init; }
+            public int Age { get; init; }
+            public Car.TrapEnum Trap { get; init; }
         }
 
         [Fact]
         public void TestStructs()
         {
             var car = connection.Query<Car>("select 'Ford' Name, 21 Age, 2 Trap").First();
+
+            Assert.Equal(21, car.Age);
+            Assert.Equal("Ford", car.Name);
+            Assert.Equal(2, (int)car.Trap);
+        }
+
+        [Fact]
+        public void TestPositionalRecord()
+        {
+            var car = connection.Query<PositionalCarRecord>("select 'Ford' Name, 21 Age, 2 Trap").First();
+
+            Assert.Equal(21, car.Age);
+            Assert.Equal("Ford", car.Name);
+            Assert.Equal(2, (int)car.Trap);
+        }
+
+        [Fact]
+        public void TestNominalRecord()
+        {
+            var car = connection.Query<NominalCarRecord>("select 'Ford' Name, 21 Age, 2 Trap").First();
 
             Assert.Equal(21, car.Age);
             Assert.Equal("Ford", car.Name);

--- a/tests/Dapper.Tests/MiscTests.cs
+++ b/tests/Dapper.Tests/MiscTests.cs
@@ -69,13 +69,16 @@ namespace Dapper.Tests
             public Car.TrapEnum Trap { get; init; }
         }
 
-        private record PositionalCarRecord(string Name, int Age, Car.TrapEnum Trap);
+        private record PositionalCarRecord(int Age, Car.TrapEnum Trap, string Name)
+        {
+            public PositionalCarRecord() : this(default, default, default) { }
+        }
 
         private record NominalCarRecord
         {
-            public string Name { get; init; }
             public int Age { get; init; }
             public Car.TrapEnum Trap { get; init; }
+            public string Name { get; init; }
         }
 
         [Fact]

--- a/tests/Dapper.Tests/ProviderTests.cs
+++ b/tests/Dapper.Tests/ProviderTests.cs
@@ -106,7 +106,7 @@ namespace Dapper.Tests
             => Test<MicrosoftSqlClientProvider>(create, test, result);
 #endif
 
-        private void Test<T>(int create, int test, bool result)
+        private static void Test<T>(int create, int test, bool result)
             where T : SqlServerDatabaseProvider, new()
         {
             var provider = new T();

--- a/tests/Dapper.Tests/Providers/MySQLTests.cs
+++ b/tests/Dapper.Tests/Providers/MySQLTests.cs
@@ -9,7 +9,7 @@ namespace Dapper.Tests
 {
     public sealed class MySqlProvider : DatabaseProvider
     {
-        public override DbProviderFactory Factory => MySql.Data.MySqlClient.MySqlClientFactory.Instance;
+        public override DbProviderFactory Factory => MySqlConnector.MySqlConnectorFactory.Instance;
         public override string GetConnectionString() =>
             GetConnectionString("MySqlConnectionString", "Server=localhost;Database=tests;Uid=test;Pwd=pass;");
 

--- a/tests/Dapper.Tests/TestBase.cs
+++ b/tests/Dapper.Tests/TestBase.cs
@@ -18,7 +18,7 @@ namespace Dapper.Tests
         public virtual void Dispose() { }
         public abstract string GetConnectionString();
 
-        protected string GetConnectionString(string name, string defaultConnectionString) =>
+        protected static string GetConnectionString(string name, string defaultConnectionString) =>
             Environment.GetEnvironmentVariable(name) ?? defaultConnectionString;
 
         public DbConnection GetOpenConnection()
@@ -85,7 +85,7 @@ namespace Dapper.Tests
         protected DbConnection GetOpenConnection() => Provider.GetOpenConnection();
         protected DbConnection GetClosedConnection() => Provider.GetClosedConnection();
         protected DbConnection _connection;
-        protected DbConnection connection => _connection ?? (_connection = Provider.GetOpenConnection());
+        protected DbConnection connection => _connection ??= Provider.GetOpenConnection();
 
         public TProvider Provider { get; } = DatabaseProvider<TProvider>.Instance;
 

--- a/tests/Dapper.Tests/TypeHandlerTests.cs
+++ b/tests/Dapper.Tests/TypeHandlerTests.cs
@@ -378,9 +378,9 @@ namespace Dapper.Tests
 
             public override RatingValue Parse(object value)
             {
-                if (value is int)
+                if (value is int i)
                 {
-                    return new RatingValue() { Value = (int)value };
+                    return new RatingValue() { Value = i };
                 }
 
                 throw new FormatException("Invalid conversion to RatingValue");

--- a/tests/Dapper.Tests/xunit.runner.json
+++ b/tests/Dapper.Tests/xunit.runner.json
@@ -1,0 +1,4 @@
+﻿{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "shadowCopy": false
+}

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -16,9 +16,9 @@
     <ProjectReference Include="../../Dapper/Dapper.csproj" />
     <ProjectReference Include="../../Dapper.Contrib/Dapper.Contrib.csproj" />
     <PackageReference Include="GitHubActionsTestLogger" Version="1.1.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">


### PR DESCRIPTION
- add .NET 5 TFM
- update package dependencies *except* for EF (here be dragons)
- fix various IDE warnings
- enable `SkipLocalsInit` on .NET 5 (in theory we could enable this more globally via a hack)