### PR TITLE
GridReader.ReadAsync normalization: Convert.ChangeType like other paths

### DIFF
--- a/Dapper/SqlMapper.GridReader.Async.cs
+++ b/Dapper/SqlMapper.GridReader.Async.cs
@@ -233,7 +233,7 @@ namespace Dapper
                     var buffer = new List<T>();
                     while (index == gridIndex && await reader.ReadAsync(cancel).ConfigureAwait(false))
                     {
-                        buffer.Add((T)deserializer(reader));
+                        buffer.Add(ConvertTo<T>(deserializer(reader)));
                     }
                     return buffer;
                 }

--- a/Dapper/SqlMapper.GridReader.cs
+++ b/Dapper/SqlMapper.GridReader.cs
@@ -182,15 +182,18 @@ namespace Dapper
                         cache.Deserializer = deserializer;
                     }
                     object val = deserializer.Func(reader);
-                    if (val == null || val is T)
+
+                    if (val != null)
                     {
-                        result = (T)val;
+                        if (val is T)
+                            result = (T)val;
+                        else
+                        {
+                            var convertToType = Nullable.GetUnderlyingType(type) ?? type;
+                            result = (T)Convert.ChangeType(val, convertToType, CultureInfo.InvariantCulture);
+                        }
                     }
-                    else
-                    {
-                        var convertToType = Nullable.GetUnderlyingType(type) ?? type;
-                        result = (T)Convert.ChangeType(val, convertToType, CultureInfo.InvariantCulture);
-                    }
+
                     if ((row & Row.Single) != 0 && reader.Read()) ThrowMultipleRows(row);
                     while (reader.Read()) { /* ignore subsequent rows */ }
                 }
@@ -363,15 +366,19 @@ namespace Dapper
                     var convertToType = Nullable.GetUnderlyingType(effectiveType) ?? effectiveType;
                     while (index == gridIndex && reader.Read())
                     {
+                        T result = default;
                         object val = deserializer(reader);
-                        if (val == null || val is T)
+                        if (val != null)
                         {
-                            yield return (T)val;
+                            if (val is T)
+                                result = (T)val;
+                            else
+                            {
+                                result = (T)Convert.ChangeType(val, convertToType, CultureInfo.InvariantCulture);
+                            }
                         }
-                        else
-                        {
-                            yield return (T)Convert.ChangeType(val, convertToType, CultureInfo.InvariantCulture);
-                        }
+
+                        yield return result;
                     }
                 }
                 finally // finally so that First etc progresses things even when multiple rows

--- a/Dapper/SqlMapper.GridReader.cs
+++ b/Dapper/SqlMapper.GridReader.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Data;
 using System.Linq;
 using System.Globalization;
+using System.Runtime.CompilerServices;
+
 namespace Dapper
 {
     public static partial class SqlMapper
@@ -418,15 +420,13 @@ namespace Dapper
                 GC.SuppressFinalize(this);
             }
 
-            private static T ConvertTo<T>(object value)
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private static T ConvertTo<T>(object value) => value switch
             {
-                if (value is null or DBNull)
-                    return default;
-                else if (value is T t)
-                    return t;
-                else
-                    return (T)Convert.ChangeType(value, Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T), CultureInfo.InvariantCulture);
-            }
+                T typed => typed,
+                null or DBNull => default,
+                _ => (T)Convert.ChangeType(value, Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T), CultureInfo.InvariantCulture),
+            };
         }
     }
 }

--- a/tests/Dapper.Tests/AsyncTests.cs
+++ b/tests/Dapper.Tests/AsyncTests.cs
@@ -241,6 +241,16 @@ namespace Dapper.Tests
         }
 
         [Fact]
+        public async Task TestMultiConversionAsync()
+        {
+            using (SqlMapper.GridReader multi = await connection.QueryMultipleAsync("select Cast(1 as BigInt) Col1; select Cast(2 as BigInt) Col2").ConfigureAwait(false))
+            {
+                Assert.Equal(1, multi.ReadAsync<int>().Result.Single());
+                Assert.Equal(2, multi.ReadAsync<int>().Result.Single());
+            }
+        }
+
+        [Fact]
         public async Task TestMultiAsyncViaFirstOrDefault()
         {
             using (SqlMapper.GridReader multi = await connection.QueryMultipleAsync("select 1; select 2; select 3; select 4; select 5").ConfigureAwait(false))

--- a/tests/Dapper.Tests/QueryMultipleTests.cs
+++ b/tests/Dapper.Tests/QueryMultipleTests.cs
@@ -32,6 +32,16 @@ namespace Dapper.Tests
         }
 
         [Fact]
+        public void TestMultiConversion()
+        {
+            using (SqlMapper.GridReader multi = connection.QueryMultiple("select Cast(1 as BigInt) Col1; select Cast(2 as BigInt) Col2"))
+            {
+                Assert.Equal(1, multi.Read<int>().Single());
+                Assert.Equal(2, multi.Read<int>().Single());
+            }
+        }
+
+        [Fact]
         public void TestQueryMultipleNonBufferedIncorrectOrder()
         {
             using (var grid = connection.QueryMultiple("select 1; select 2; select @x; select 4", new { x = 3 }))


### PR DESCRIPTION
This does proper type conversion like other paths so everything aligns. Fix for #1301, #1496, and #1648. Added tests that fail against current code here.