### PR TITLE
Added overloads allowing predicate expressions to limit scope

### DIFF
--- a/Dapper.Contrib/SqlMapperExtensions.Expression.Async.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.Expression.Async.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Dapper.Contrib.Extensions
+{
+    public static partial class SqlMapperExtensions
+    {
+        /// <summary>
+        /// Returns a list of entities from table "Ts" based on predicate expression.  
+        /// Id of T must be marked with [Key] attribute.
+        /// Entities created from interfaces are tracked/intercepted for changes and used by the Update() extension
+        /// for optimal performance.
+        /// Entities can be filtered using predicate expression
+        /// </summary>
+        /// <typeparam name="T">Interface or type to create and populate</typeparam>
+        /// <param name="connection">Open SqlConnection</param>
+        /// <param name="predicate">Search terms</param>
+        /// <param name="transaction">The transaction to run under, null (the default) if none</param>
+        /// <param name="commandTimeout">Number of seconds before command execution timeout</param>
+        /// <returns>Entity of T</returns>
+        public static Task<IEnumerable<T>> GetAllAsync<T>(this IDbConnection connection, Expression<Func<T, bool>> predicate,
+            IDbTransaction transaction = null, int? commandTimeout = null) where T : class
+        {
+            var type = typeof(T);
+            var cacheType = typeof(List<T>);
+
+            if (!GetQueries.TryGetValue(cacheType.TypeHandle, out string sql))
+            {
+                GetSingleKey<T>(nameof(GetAll));
+                var name = GetTableName(type);
+
+                var where = CreateWhereClause(predicate);
+
+                sql = $"SELECT * FROM {name} {where}";
+                GetQueries[cacheType.TypeHandle] = sql;
+            }
+
+            return !type.IsInterface
+                ? connection.QueryAsync<T>(sql, null, transaction, commandTimeout)
+                : GetAllAsyncImpl<T>(connection, transaction, commandTimeout, sql, type);
+        }
+
+        /// <summary>
+        /// Delete n matching entities in the table related to the type T asynchronously using Task based.
+        /// </summary>
+        /// <typeparam name="T">Type of entity</typeparam>
+        /// <param name="connection">Open SqlConnection</param>
+        /// <param name="predicate">Filter to apply for deletion</param>
+        /// <param name="transaction">The transaction to run under, null (the default) if none</param>
+        /// <param name="commandTimeout">Number of seconds before command execution timeout</param>
+        /// <returns>true if deleted, false if none found</returns>
+        public static async Task<bool> DeleteAllAsync<T>(this IDbConnection connection, Expression<Func<T, bool>> predicate,
+            IDbTransaction transaction = null, int? commandTimeout = null) where T : class
+        {
+            var type = typeof(T);
+            var where = CreateWhereClause(predicate);
+
+            var statement = $"DELETE FROM {GetTableName(type)} {where}";
+            var deleted = await connection.ExecuteAsync(statement, null, transaction, commandTimeout).ConfigureAwait(false);
+            return deleted > 0;
+        }
+
+        private static string CreateWhereClause<T>(Expression<Func<T, bool>> predicate)
+        {
+            if (predicate == null)
+                return "";
+
+            var p = new StringBuilder(predicate.Body.ToString());
+            var pName = predicate.Parameters.First();
+            p.Replace(pName.Name + ".", "");
+            p.Replace("==", "=");
+            p.Replace("AndAlso", "and");
+            p.Replace("OrElse", "or");
+            p.Replace("\"", "\'");
+            return $"WHERE {p}";
+        }
+    }
+}

--- a/tests/Dapper.Tests.Contrib/TestSuite.Expressions.Async.cs
+++ b/tests/Dapper.Tests.Contrib/TestSuite.Expressions.Async.cs
@@ -1,0 +1,111 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Dapper.Contrib.Extensions;
+using Xunit;
+
+namespace Dapper.Tests.Contrib
+{
+    public abstract partial class TestSuite
+    {
+        [Fact]
+        public async Task GetAllAsyncWithOrExpression()
+        {
+            const int numberOfEntities = 10;
+
+            var users = new List<User>(numberOfEntities);
+
+            for (var i = 0; i < numberOfEntities; i++)
+                users.Add(new User {Name = "User " + i, Age = i});
+
+            using (var connection = GetOpenConnection())
+            {
+                await connection.DeleteAllAsync<User>().ConfigureAwait(false);
+
+                var total = await connection.InsertAsync(users).ConfigureAwait(false);
+                Assert.Equal(total, numberOfEntities);
+
+                users = (List<User>) await connection.GetAllAsync<User>(x => x.Age == 5 || x.Age == 6).ConfigureAwait(false);
+                Assert.Equal(2, users.Count);
+                Assert.NotNull(users.FirstOrDefault(x => x.Age == 5));
+                Assert.NotNull(users.FirstOrDefault(x => x.Age == 6));
+
+                var iusers = await connection.GetAllAsync<IUser>(x => x.Age == 5 || x.Age == 6).ConfigureAwait(false);
+                Assert.Equal(2, iusers.Count());
+                Assert.NotNull(iusers.FirstOrDefault(x => x.Age == 5));
+                Assert.NotNull(iusers.FirstOrDefault(x => x.Age == 6));
+            }
+        }
+
+        [Fact]
+        public async Task GetAllAsyncWithAndExpression()
+        {
+            const int numberOfEntities = 10;
+
+            var users = new List<User>(numberOfEntities);
+
+            for (var i = 0; i < numberOfEntities; i++)
+                users.Add(new User {Name = "User " + i, Age = i});
+
+            using (var connection = GetOpenConnection())
+            {
+                await connection.DeleteAllAsync<User>().ConfigureAwait(false);
+
+                var total = await connection.InsertAsync(users).ConfigureAwait(false);
+                Assert.Equal(total, numberOfEntities);
+
+                users = (List<User>) await connection.GetAllAsync<User>(x => x.Age == 5 && x.Id == 6).ConfigureAwait(false);
+                Assert.Single(users);
+                Assert.NotNull(users.FirstOrDefault(x => x.Age == 5 && x.Id == 6));
+
+                var iusers = await connection.GetAllAsync<IUser>(x => x.Age == 5 && x.Id == 6).ConfigureAwait(false);
+                Assert.Single(iusers);
+                Assert.NotNull(iusers.FirstOrDefault(x => x.Age == 5 && x.Id == 6));
+            }
+        }
+
+        [Fact]
+        public async Task GetAllAsyncWithStringExpression()
+        {
+            const int numberOfEntities = 10;
+
+            var users = new List<User>(numberOfEntities);
+
+            for (var i = 0; i < numberOfEntities; i++)
+                users.Add(new User {Id = 100 + i, Name = "User " + i, Age = i});
+
+            using (var connection = GetOpenConnection())
+            {
+                await connection.DeleteAllAsync<User>().ConfigureAwait(false);
+
+                var total = await connection.InsertAsync(users).ConfigureAwait(false);
+                Assert.Equal(total, numberOfEntities);
+
+                users = (List<User>) await connection.GetAllAsync<User>(x => x.Name == "User 5").ConfigureAwait(false);
+                Assert.Single(users);
+                Assert.NotNull(users.FirstOrDefault(x => x.Name == "User 5"));
+
+                var iusers = await connection.GetAllAsync<IUser>(x => x.Name == "User 5").ConfigureAwait(false);
+                Assert.Single(iusers);
+                Assert.NotNull(iusers.FirstOrDefault(x => x.Name == "User 5"));
+            }
+        }
+
+        [Fact]
+        public async Task DeleteAllAsyncWithExpression()
+        {
+            using (var connection = GetOpenConnection())
+            {
+                await connection.DeleteAllAsync<User>().ConfigureAwait(false);
+
+                var id1 = await connection.InsertAsync(new User {Name = "Alice", Age = 32}).ConfigureAwait(false);
+                var id2 = await connection.InsertAsync(new User {Name = "Bob", Age = 33}).ConfigureAwait(false);
+
+                await connection.DeleteAllAsync<User>(x => x.Name == "Alice").ConfigureAwait(false);
+
+                Assert.Null(await connection.GetAsync<User>(id1).ConfigureAwait(false));
+                Assert.NotNull(await connection.GetAsync<User>(id2).ConfigureAwait(false));
+            }
+        }
+    }
+}


### PR DESCRIPTION
_DeleteAllAsync()_ and _GetAllAsync()_ overloads accept a predicate expression that can be used to limit the scope of the action. I.E filter records returned or deleted.

This is obviously limited compared to what you can achieve with the QueryAsync or ExecuteAsync methods but does allow you to stay in the Dapper.Contrib world for simple use cases and not require any SQL strings.

For example to return entities where Age = 5:

`await connection.GetAllAsync<User>(x => x.Age == 5) `

For example to delete entities where Age = 5:

`await connection.DeleteAllAsync<User>(x => x.Age == 5) `

Some supporting tests have been added.