### PR TITLE
Belgrade benchmark bug fix.

### DIFF
--- a/benchmarks/Dapper.Tests.Performance/Benchmarks.Belgrade.cs
+++ b/benchmarks/Dapper.Tests.Performance/Benchmarks.Belgrade.cs
@@ -18,30 +18,28 @@ namespace Dapper.Tests.Performance
             _mapper = new QueryMapper(ConnectionString);
         }
 
-        [Benchmark(Description = "ExecuteReader")]
-        public async Task<Post> ExecuteReader()
+        [Benchmark(Description = "FirstOrDefault")]
+        public Task<Post> FirstOrDefault()
         {
             Step();
-            var post = new Post();
-            await _mapper.Sql("SELECT TOP 1 * FROM Posts WHERE Id = @Id").Param("Id", i).Map(
-                        reader =>
-                        {
-                            post.Id = reader.GetInt32(0);
-                            post.Text = reader.GetString(1);
-                            post.CreationDate = reader.GetDateTime(2);
-                            post.LastChangeDate = reader.GetDateTime(3);
+            return _mapper.Sql("SELECT TOP 1 * FROM Posts WHERE Id = @Id").Param("Id", i).FirstOrDefault(
+                reader => new Post
+                    {
+                        Id = reader.GetInt32(0),
+                        Text = reader.GetString(1),
+                        CreationDate = reader.GetDateTime(2),
+                        LastChangeDate = reader.GetDateTime(3),
 
-                            post.Counter1 = reader.IsDBNull(4) ? null : (int?)reader.GetInt32(4);
-                            post.Counter2 = reader.IsDBNull(5) ? null : (int?)reader.GetInt32(5);
-                            post.Counter3 = reader.IsDBNull(6) ? null : (int?)reader.GetInt32(6);
-                            post.Counter4 = reader.IsDBNull(7) ? null : (int?)reader.GetInt32(7);
-                            post.Counter5 = reader.IsDBNull(8) ? null : (int?)reader.GetInt32(8);
-                            post.Counter6 = reader.IsDBNull(9) ? null : (int?)reader.GetInt32(9);
-                            post.Counter7 = reader.IsDBNull(10) ? null : (int?)reader.GetInt32(10);
-                            post.Counter8 = reader.IsDBNull(11) ? null : (int?)reader.GetInt32(11);
-                            post.Counter9 = reader.IsDBNull(12) ? null : (int?)reader.GetInt32(12);
-                        });
-            return post;
+                        Counter1 = reader.IsDBNull(4) ? null : (int?)reader.GetInt32(4),
+                        Counter2 = reader.IsDBNull(5) ? null : (int?)reader.GetInt32(5),
+                        Counter3 = reader.IsDBNull(6) ? null : (int?)reader.GetInt32(6),
+                        Counter4 = reader.IsDBNull(7) ? null : (int?)reader.GetInt32(7),
+                        Counter5 = reader.IsDBNull(8) ? null : (int?)reader.GetInt32(8),
+                        Counter6 = reader.IsDBNull(9) ? null : (int?)reader.GetInt32(9),
+                        Counter7 = reader.IsDBNull(10) ? null : (int?)reader.GetInt32(10),
+                        Counter8 = reader.IsDBNull(11) ? null : (int?)reader.GetInt32(11),
+                        Counter9 = reader.IsDBNull(12) ? null : (int?)reader.GetInt32(12),
+                    });
         }
     }
 }

--- a/benchmarks/Dapper.Tests.Performance/Benchmarks.Belgrade.cs
+++ b/benchmarks/Dapper.Tests.Performance/Benchmarks.Belgrade.cs
@@ -2,6 +2,7 @@
 using Belgrade.SqlClient.SqlDb;
 using Belgrade.SqlClient;
 using System.ComponentModel;
+using System.Threading.Tasks;
 
 namespace Dapper.Tests.Performance
 {
@@ -18,11 +19,11 @@ namespace Dapper.Tests.Performance
         }
 
         [Benchmark(Description = "ExecuteReader")]
-        public Post ExecuteReader()
+        public async Task<Post> ExecuteReader()
         {
             Step();
             var post = new Post();
-            _mapper.Sql("SELECT TOP 1 * FROM Posts WHERE Id = @Id").Param("Id", i).Map(
+            await _mapper.Sql("SELECT TOP 1 * FROM Posts WHERE Id = @Id").Param("Id", i).Map(
                         reader =>
                         {
                             post.Id = reader.GetInt32(0);


### PR DESCRIPTION
The used Map method is asynchronous, hence without waiting for operation to complete the benchmark is only counting the query invocation time.