### PR TITLE
[Benchmarks] Add SqlMarshal benhmarks

### DIFF
--- a/benchmarks/Dapper.Tests.Performance/Benchmarks.SqlMarshal.cs
+++ b/benchmarks/Dapper.Tests.Performance/Benchmarks.SqlMarshal.cs
@@ -1,0 +1,25 @@
+﻿using BenchmarkDotNet.Attributes;
+using System.ComponentModel;
+
+namespace Dapper.Tests.Performance
+{
+    [Description("SqlMarshal")]
+    public partial class SqlMarshalBenchmarks : BenchmarkBase
+    {
+        [GlobalSetup]
+        public void Setup()
+        {
+            BaseSetup();
+        }
+
+        [Benchmark(Description = "SqlCommand")]
+        public Post SqlCommand()
+        {
+            Step();
+            return ReadPost("select Top 1 * from Posts where Id = @id", i);
+        }
+
+        [SqlMarshal("")]
+        private partial Post ReadPost([RawSql]string sql, int id);
+    }
+}

--- a/benchmarks/Dapper.Tests.Performance/Dapper.Tests.Performance.csproj
+++ b/benchmarks/Dapper.Tests.Performance/Dapper.Tests.Performance.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="Npgsql" Version="5.0.0" />
     <PackageReference Include="PetaPoco" Version="5.1.306" />
     <PackageReference Include="ServiceStack.OrmLite.SqlServer" Version="5.10.2" />
+    <PackageReference Include="SqlMarshal" Version="0.1.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
     <PackageReference Include="System.Data.SQLite" Version="1.0.113.6" />
   </ItemGroup>


### PR DESCRIPTION
[SqlMarshal](https://github.com/kant2002/sqlmarshal) is NativeAOT friendly mini-ORM which uses source code generators.

```
// * Summary *

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
Intel Core i7-6700HQ CPU 2.60GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=5.0.201
  [Host]   : .NET Core 3.1.13 (CoreCLR 4.700.21.11102, CoreFX 4.700.21.11602), X64 RyuJIT
  ShortRun : .NET Core 3.1.13 (CoreCLR 4.700.21.11102, CoreFX 4.700.21.11602), X64 RyuJIT

|            ORM |                        Method |  Return |     Mean |    StdDev |     Error |   Gen 0 |  Gen 1 |  Gen 2 | Allocated |
|--------------- |------------------------------ |-------- |---------:|----------:|----------:|--------:|-------:|-------:|----------:|
|       Belgrade |                 ExecuteReader |    Post | 119.0 us |  22.26 us |  37.41 us |  2.6250 | 1.0000 |      - |  13.53 KB |
|     Hand Coded |                     DataTable | dynamic | 123.9 us |   2.95 us |   5.64 us |  3.0000 |      - |      - |   9.37 KB |
|     Hand Coded |                    SqlCommand |    Post | 124.8 us |  16.91 us |  32.33 us |  1.2500 | 0.5000 |      - |   7.42 KB |
|     SqlMarshal |                    SqlCommand |    Post | 132.8 us |   2.77 us |   4.66 us |  2.0000 | 0.7500 |      - |  11.27 KB |
|         Dapper |  QueryFirstOrDefault<dynamic> | dynamic | 135.0 us |   3.64 us |   6.96 us |  3.5000 |      - |      - |  11.39 KB |
|     LINQ to DB |                      Query<T> |    Post | 135.9 us |   3.52 us |   5.92 us |  1.7500 | 0.7500 |      - |  10.64 KB |
|     LINQ to DB |            'First (Compiled)' |    Post | 136.5 us |   2.99 us |   5.72 us |  1.7500 | 0.7500 |      - |  11.23 KB |
|       PetaPoco |             'Fetch<T> (Fast)' |    Post | 136.8 us |   4.67 us |   7.85 us |  2.0000 | 1.0000 |      - |  11.52 KB |
|         Dapper |   'Query<dynamic> (buffered)' | dynamic | 137.6 us |   6.44 us |  12.31 us |  2.0000 | 1.0000 |      - |  11.72 KB |
|         Mighty |                Query<dynamic> | dynamic | 141.7 us |   4.99 us |   9.54 us |  2.0000 | 1.0000 |      - |  12.43 KB |
|        Massive |             'Query (dynamic)' | dynamic | 142.1 us |   1.59 us |   2.66 us |  2.0000 | 1.0000 |      - |  12.07 KB |
|         Dapper |         'Query<T> (buffered)' |    Post | 143.0 us |   7.98 us |  13.41 us |  2.0000 | 1.0000 |      - |  11.64 KB |
|         Mighty |      SingleFromQuery<dynamic> | dynamic | 144.8 us |   3.95 us |   6.64 us |  2.5000 | 1.0000 |      - |  12.43 KB |
|         Dapper |        QueryFirstOrDefault<T> |    Post | 147.0 us |  22.39 us |  42.80 us |  1.7500 | 0.7500 |      - |  11.35 KB |
|       PetaPoco |                      Fetch<T> |    Post | 149.2 us |  22.91 us |  43.80 us |  2.5000 | 1.0000 | 0.2500 |   12.2 KB |
|         Dapper |              'Contrib Get<T>' |    Post | 149.9 us |  13.30 us |  25.42 us |  2.0000 | 1.0000 |      - |  12.28 KB |
|   ServiceStack |                 SingleById<T> |    Post | 151.8 us |   3.95 us |   7.56 us |  2.7500 | 1.0000 | 0.2500 |  15.27 KB |
|         Mighty |            SingleFromQuery<T> |    Post | 152.5 us |  14.77 us |  24.83 us |  2.0000 | 1.0000 |      - |  12.53 KB |
|         Mighty |                      Query<T> |    Post | 162.7 us |  45.49 us |  76.44 us |  2.0000 | 1.0000 |      - |  12.53 KB |
|         Dapper |       'Query<T> (unbuffered)' |    Post | 191.4 us |   6.95 us |  11.67 us |  2.2500 | 1.0000 | 0.2500 |  11.76 KB |
|     LINQ to DB |                         First |    Post | 200.6 us |  24.67 us |  47.18 us |  2.7500 | 1.0000 | 0.2500 |  15.79 KB |
| DevExpress.XPO |             GetObjectByKey<T> |    Post | 204.8 us |   5.69 us |  10.89 us |  5.5000 | 1.5000 |      - |  29.16 KB |
|        EF Core |            'First (Compiled)' |    Post | 212.4 us |  15.70 us |  30.01 us |  2.5000 |      - |      - |   8.39 KB |
|           EF 6 |                      SqlQuery |    Post | 251.1 us |  92.97 us | 140.55 us |  3.7500 | 1.0000 |      - |  23.67 KB |
|         Dapper | 'Query<dynamic> (unbuffered)' | dynamic | 255.9 us |  99.08 us | 149.80 us |  2.5000 | 1.0000 | 0.2500 |   11.8 KB |
| DevExpress.XPO |                      Query<T> |    Post | 285.4 us |  92.67 us | 140.10 us | 10.2500 |      - |      - |  31.71 KB |
|     NHibernate |                           HQL |    Post | 289.8 us |  18.26 us |  34.92 us |  5.5000 | 1.0000 |      - |  31.32 KB |
|     NHibernate |                        Get<T> |    Post | 302.1 us |  16.69 us |  28.05 us |  5.5000 | 1.0000 |      - |  29.37 KB |
|        EF Core |         'First (No Tracking)' |    Post | 334.9 us |  50.05 us |  84.11 us |  3.5000 | 0.5000 |      - |  19.53 KB |
|           EF 6 |                         First |    Post | 339.4 us |  43.67 us |  66.03 us | 14.0000 |      - |      - |  44.18 KB |
|        EF Core |                      SqlQuery |    Post | 344.0 us |  55.47 us |  83.86 us |  5.5000 |      - |      - |  17.59 KB |
|        EF Core |                         First |    Post | 357.5 us |  51.72 us |  78.20 us |  4.0000 |      - |      - |   12.3 KB |
|     NHibernate |                      Criteria |    Post | 357.6 us |  37.63 us |  63.23 us | 11.5000 | 1.0000 |      - |   56.5 KB |
|           EF 6 |         'First (No Tracking)' |    Post | 383.1 us |  33.98 us |  57.10 us |  9.0000 | 1.0000 |      - |  50.95 KB |
|     NHibernate |                           SQL |    Post | 399.2 us |  40.65 us |  68.31 us | 19.0000 | 1.0000 |      - |   78.9 KB |
| DevExpress.XPO |                 FindObject<T> |    Post | 602.5 us | 361.92 us | 547.18 us |  8.0000 |      - |      - |   27.2 KB |
|     NHibernate |                          LINQ |    Post | 925.9 us |  47.62 us |  80.02 us | 12.0000 | 2.0000 |      - |  53.59 KB |
```