### PR TITLE
Use value-type accessors instead of GetValue to avoid boxing

### DIFF
--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -3628,7 +3628,6 @@ namespace Dapper
             else if ((op = GetOperator(from, to)) != null)
             {
                 // this is handy for things like decimal <===> double
-                //il.Emit(OpCodes.Unbox_Any, from); // stack is now [target][target][data-typed-value]
                 il.Emit(OpCodes.Call, op); // stack is now [target][target][typed-value]
             }
             else

--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -3218,8 +3218,11 @@ namespace Dapper
                     LoadDefaultValue(il, targetType);
 
                     il.MarkLabel(finishLabel);
-                    // without this cast an VerificationException is thrown when JITing
-                    il.Emit(OpCodes.Castclass, targetType);
+                    if (targetType.IsValueType == false)
+                    {
+                        // without this cast a VerificationException is thrown when JITing
+                        il.Emit(OpCodes.Castclass, targetType);
+                    }
                 }
                 else
                 {

--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -3246,8 +3246,19 @@ namespace Dapper
         static bool GetColumnAllowsDBNull(IDataReader reader, int ordinal)
         {
 #if NET461
-            // Could use GetSchemaTable to try to determine if AllowDbNull is set or not.
-            // GetSchemaTable is ugly to work with though, so for now, just assume yes.
+            var schema = reader.GetSchemaTable();
+            if(schema != null)
+            {
+                var col = schema.Columns["AllowDBNull"];
+                if (col != null)
+                {
+                    object allowDBNull = schema.Rows[ordinal][col];
+                    if (allowDBNull is bool b && b == false)
+                    {
+                        return false;
+                    }
+                }
+            }
             return true;
 #else
             // At least for SqlClient, the schema objects get cached internally, so calling

--- a/benchmarks/Dapper.Tests.Performance/Benchmarks.Dapper.cs
+++ b/benchmarks/Dapper.Tests.Performance/Benchmarks.Dapper.cs
@@ -1,5 +1,6 @@
 ﻿using BenchmarkDotNet.Attributes;
 using Dapper.Contrib.Extensions;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 
@@ -12,6 +13,12 @@ namespace Dapper.Tests.Performance
         public void Setup()
         {
             BaseSetup();
+        }
+
+        [Benchmark(Description = "Query all posts")]
+        public List<Post> QueryAllPost()
+        {           
+            return _connection.Query<Post>("select * from PostsLite").ToList();
         }
 
         [Benchmark(Description = "Query<T> (buffered)")]

--- a/benchmarks/Dapper.Tests.Performance/Program.cs
+++ b/benchmarks/Dapper.Tests.Performance/Program.cs
@@ -56,6 +56,9 @@ namespace Dapper.Tests.Performance
                 cnn.Open();
                 var cmd = cnn.CreateCommand();
                 cmd.CommandText = @"
+
+Declare @i int = 0;
+
 If (Object_Id('Posts') Is Null)
 Begin
 	Create Table Posts
@@ -76,11 +79,40 @@ Begin
 	);
 	   
 	Set NoCount On;
-	Declare @i int = 0;
+    Set @i = 0;
 
 	While @i <= 5001
 	Begin
 		Insert Posts ([Text],CreationDate, LastChangeDate) values (replicate('x', 2000), GETDATE(), GETDATE());
+		Set @i = @i + 1;
+	End
+End
+
+If (Object_Id('PostsLite') Is Null)
+Begin
+	Create Table PostsLite
+	(
+		Id int identity primary key, 
+		[Text] varchar(max) not null, 
+		CreationDate datetime not null, 
+		LastChangeDate datetime not null,
+		Counter1 int not null,
+		Counter2 int not null,
+		Counter3 int not null,
+		Counter4 int not null,
+		Counter5 int not null,
+		Counter6 int not null,
+		Counter7 int not null,
+		Counter8 int not null,
+		Counter9 int not null
+	);
+	   
+	Set NoCount On;
+	Set @i = 0;
+
+	While @i <= 5001
+	Begin
+		Insert PostsLite values ('Test text', GETDATE(), GETDATE(), 1, 2, 3, 4, 5, 6, 7, 8, 9);
 		Set @i = @i + 1;
 	End
 End

--- a/tests/Dapper.Tests/TypeHandlerTests.cs
+++ b/tests/Dapper.Tests/TypeHandlerTests.cs
@@ -641,7 +641,7 @@ namespace Dapper.Tests
         {
             Guid guid = Guid.Parse("cf0ef7ac-b6fe-4e24-aeda-a2b45bb5654e");
             var ex = Assert.ThrowsAny<Exception>(() => connection.Query<Issue149_Person>("select @guid as Id", new { guid }).First());
-            Assert.Equal("Error parsing column 0 (Id=cf0ef7ac-b6fe-4e24-aeda-a2b45bb5654e - Object)", ex.Message);
+            Assert.Equal("Error parsing column 0 (Id=[Guid value])", ex.Message);
         }
 
         public class Issue149_Person { public string Id { get; set; } }


### PR DESCRIPTION
This modifies the ILEmit data binder code to use the value-type accessors on IDataReader (GetInt32, GetFloat, GetDateTime, etc) instead of GetValue to avoid boxing the values. It also avoids calling IsDBNull for columns where the schema indicates that the value will never be null.

I added a benchmark which reads the entire (modified) Posts table. The original posts table had a large (2k) text column that seemed to dominate the benchmark time. I reduced this data to "Test text", and made all of the `CounterX` columns non-nullable to try to measure the IsDBNull optimization.

Results of this change as measured on my machine:

NET48:

|    ORM |         Method | MODE |     Mean |   StdDev |    Error |    Gen 0 |    Gen 1 |   Gen 2 | Allocated |
|------- |--------------- |------- |---------:|---------:|---------:|---------:|---------:|--------:|----------:|
| Dapper | 'Query extent' | Before | 11.57 ms | 0.361 ms | 0.545 ms | 462.0000 | 100.0000 | 12.0000 |   2.66 MB |
| Dapper | 'Query extent' | After | 9.533 ms | 0.2729 ms | 0.4126 ms | 234.0000 | 76.0000 | 10.0000 |   1.28 MB |

NET5.0:

|    ORM |         Method | MODE|     Mean |    StdDev |     Error |    Gen 0 |   Gen 1 |   Gen 2 | Allocated |
|------- |--------------- |------- |---------:|----------:|----------:|---------:|--------:|--------:|----------:|
| Dapper | 'Query extent' | Before | 7.886 ms | 0.0470 ms | 0.0790 ms | 428.0000 | 96.0000 | 10.0000 |    2.5 MB |
| Dapper | 'Query extent' | After | 6.497 ms | 0.0373 ms | 0.0714 ms | 204.0000 | 70.0000 | 8.0000 |   1.12 MB |

As expected, this results in a significant reduction in allocation, and also affords a moderate improvement in performance for this specific benchmark.

There is one minor breaking change: conveying the value of value-type fields to the exception catch block is very difficult without boxing it. Rather than doing that, I opted to instead convey the *type* of the value-type only. The effect of this change can be seen in one of the unit tests, the message doesn't display the specific value anymore (for value-type columns only), but will still display the ordinal and the field type. I hope this is an acceptable break. I think the impact should be low, because the majority of exceptions would likely occur when processing string values, which would still have their value available in the exception message because they are ref-types.

All of the Dapper unit tests pass. I do worry a bit about edge cases though, as in my limited experience bugs in this code tend to result in one of InvalidProgramException, VerificationException or AccessViolationException, all of which are bad and the the last of which is catastrophic. Certainly a thorough review by someone more familiar with ILEmit is in order.