### PR TITLE
GridReader.ReadAsync normalization: Convert.ChangeType like other paths

### DIFF
--- a/tests/Dapper.Tests/AsyncTests.cs
+++ b/tests/Dapper.Tests/AsyncTests.cs
@@ -241,6 +241,16 @@ namespace Dapper.Tests
         }
 
         [Fact]
+        public async Task TestMultiConversionAsync()
+        {
+            using (SqlMapper.GridReader multi = await connection.QueryMultipleAsync("select Cast(1 as BigInt) Col1; select Cast(2 as BigInt) Col2").ConfigureAwait(false))
+            {
+                Assert.Equal(1, multi.ReadAsync<int>().Result.Single());
+                Assert.Equal(2, multi.ReadAsync<int>().Result.Single());
+            }
+        }
+
+        [Fact]
         public async Task TestMultiAsyncViaFirstOrDefault()
         {
             using (SqlMapper.GridReader multi = await connection.QueryMultipleAsync("select 1; select 2; select 3; select 4; select 5").ConfigureAwait(false))

--- a/tests/Dapper.Tests/QueryMultipleTests.cs
+++ b/tests/Dapper.Tests/QueryMultipleTests.cs
@@ -32,6 +32,16 @@ namespace Dapper.Tests
         }
 
         [Fact]
+        public void TestMultiConversion()
+        {
+            using (SqlMapper.GridReader multi = connection.QueryMultiple("select Cast(1 as BigInt) Col1; select Cast(2 as BigInt) Col2"))
+            {
+                Assert.Equal(1, multi.Read<int>().Single());
+                Assert.Equal(2, multi.Read<int>().Single());
+            }
+        }
+
+        [Fact]
         public void TestQueryMultipleNonBufferedIncorrectOrder()
         {
             using (var grid = connection.QueryMultiple("select 1; select 2; select @x; select 4", new { x = 3 }))


### PR DESCRIPTION
This does proper type conversion like other paths so everything aligns. Fix for #1496 and #1648. Added tests that fail against current code here.

We should follow-up here with an aggressively inlined shared approach, but getting everything normalized first.

