### PR TITLE
Add DbString.ToString() overload

### DIFF
--- a/Dapper/DbString.cs
+++ b/Dapper/DbString.cs
@@ -44,6 +44,13 @@ namespace Dapper
         /// The value of the string
         /// </summary>
         public string Value { get; set; }
+        
+        /// <summary>
+        /// Gets a string representation of this DbString.
+        /// </summary>
+        public override string ToString() =>
+            $"Dapper.DbString (Value: '{Value}', Length: {Length}, IsAnsi: {IsAnsi}, IsFixedLength: {IsFixedLength})";
+
         /// <summary>
         /// Add the parameter to the command... internal use only
         /// </summary>

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,8 @@ Note: to get the latest pre-release build, add ` -Pre` to the end of the command
 - Parameters can now be re-used on subsequent commands (#952 via jamescrowley)
 - Array query support (`.Query<int[]>`) on supported platforms (e.g. Postgres) (#1598 via DarkWanderer)
 - `SqlMapper.HasTypeHandler` is made public for consumers (#1405 via brendangooden)
-- Improves multi-mapping error message when a specified column in splitOn can't be found (#1664 by NickCraver)
+- Improves multi-mapping error message when a specified column in splitOn can't be found (#1664 via NickCraver)
+- Improves DbString.ToString() (#1665 via NickCraver)
 
 ### 2.0.90
 

--- a/tests/Dapper.Tests/MiscTests.cs
+++ b/tests/Dapper.Tests/MiscTests.cs
@@ -656,6 +656,24 @@ select * from @bar", new { foo }).Single();
         }
 
         [Fact]
+        public void TestDbStringToString()
+        {
+            Assert.Equal("Dapper.DbString (Value: 'abcde', Length: 10, IsAnsi: True, IsFixedLength: True)", 
+                new DbString { Value = "abcde", IsFixedLength = true, Length = 10, IsAnsi = true }.ToString());
+            Assert.Equal("Dapper.DbString (Value: 'abcde', Length: 10, IsAnsi: False, IsFixedLength: True)",
+                new DbString { Value = "abcde", IsFixedLength = true, Length = 10, IsAnsi = false }.ToString());
+            Assert.Equal("Dapper.DbString (Value: 'abcde', Length: 10, IsAnsi: True, IsFixedLength: False)",
+                new DbString { Value = "abcde", IsFixedLength = false, Length = 10, IsAnsi = true }.ToString());
+            Assert.Equal("Dapper.DbString (Value: 'abcde', Length: 10, IsAnsi: False, IsFixedLength: False)",
+                new DbString { Value = "abcde", IsFixedLength = false, Length = 10, IsAnsi = false }.ToString());
+
+            Assert.Equal("Dapper.DbString (Value: 'abcde', Length: -1, IsAnsi: True, IsFixedLength: False)",
+                new DbString { Value = "abcde", IsAnsi = true }.ToString());
+            Assert.Equal("Dapper.DbString (Value: 'abcde', Length: -1, IsAnsi: False, IsFixedLength: False)",
+                new DbString { Value = "abcde", IsAnsi = false }.ToString());
+        }
+
+        [Fact]
         public void TestDefaultDbStringDbType()
         {
             var origDefaultStringDbType = DbString.IsAnsiDefault;


### PR DESCRIPTION
Fixes #1538 and #1545 by making DbString.ToString() much more descriptive.