### PR TITLE
Enables "snowflake" connection

### DIFF
--- a/Dapper/SqlMapper.Settings.cs
+++ b/Dapper/SqlMapper.Settings.cs
@@ -93,6 +93,12 @@ namespace Dapper
             /// operation if there are this many elements or more. Note that this feature requires SQL Server 2016 / compatibility level 130 (or above).
             /// </summary>
             public static int InListStringSplitCount { get; set; } = -1;
+
+            /// <summary>
+            /// If set, pseudo-positional parameters (i.e. ?foo?) are passed using auto-generated incremental names, i.e. "1", "2", "3"
+            /// instead of the original name; for most scenarios, this is ignored since the name is redundant, but "snowflake" requires this.
+            /// </summary>
+            public static bool UseIncrementalPseudoPositionalParameterNames { get; set; }
         }
     }
 }

--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -1778,6 +1778,8 @@ namespace Dapper
             }
             HashSet<string> consumed = new HashSet<string>(StringComparer.Ordinal);
             bool firstMatch = true;
+            int index = 0; // use this to spoof names; in most pseudo-positional cases, the name is ignored, however:
+                           // for "snowflake", the name needs to be incremental i.e. "1", "2", "3"
             cmd.CommandText = pseudoPositional.Replace(cmd.CommandText, match =>
             {
                 string key = match.Groups[1].Value;
@@ -1793,6 +1795,10 @@ namespace Dapper
                         cmd.Parameters.Clear(); // only clear if we are pretty positive that we've found this pattern successfully
                     }
                     // if found, return the anonymous token "?"
+                    if (Settings.UseIncrementalPseudoPositionalParameterNames)
+                    {
+                        param.ParameterName = (++index).ToString();
+                    }
                     cmd.Parameters.Add(param);
                     parameters.Remove(key);
                     consumed.Add(key);

--- a/tests/Dapper.Tests/Dapper.Tests.csproj
+++ b/tests/Dapper.Tests/Dapper.Tests.csproj
@@ -20,10 +20,9 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="MySqlConnector" Version="1.1.0" />
     <PackageReference Include="Npgsql" Version="5.0.0" />
+    <PackageReference Include="Snowflake.Data" Version="2.0.3" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-
-
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net472'">

--- a/tests/Dapper.Tests/Providers/SnowflakeTests.cs
+++ b/tests/Dapper.Tests/Providers/SnowflakeTests.cs
@@ -1,0 +1,86 @@
+﻿#if !NET462 // platform not supported exception
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Snowflake.Data.Client;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Dapper.Tests
+{
+    public class SnowflakeTests
+    {
+        static readonly string s_ConnectionString;
+        static SnowflakeTests()
+        {
+            SqlMapper.Settings.UseIncrementalPseudoPositionalParameterNames = true;
+
+            try
+            { // this *probably* won't exist (TODO: can we get a test account?)
+                s_ConnectionString = File.ReadAllText(@"c:\Code\SnowflakeConnectionString.txt").Trim();
+            } catch { }
+        }
+
+        public SnowflakeTests(ITestOutputHelper output)
+            => Output = output;
+
+        private ITestOutputHelper Output { get; }
+
+        
+        private static SnowflakeDbConnection GetConnection()
+        {
+            if (string.IsNullOrWhiteSpace(s_ConnectionString))
+                Skip.Inconclusive("no snowflake connection-string");
+
+            return new SnowflakeDbConnection
+            {
+                ConnectionString = s_ConnectionString
+            };
+        }
+
+        [Fact]
+        public void Connect()
+        {
+            using var connection = GetConnection();
+            connection.Open();
+        }
+
+
+        [Fact]
+        public void BasicQuery()
+        {
+
+            using var connection = GetConnection();
+            var nations = connection.Query<Nation>(@"SELECT * FROM NATION").AsList();
+            Assert.NotEmpty(nations);
+            Output.WriteLine($"nations: {nations.Count}");
+            foreach (var nation in nations)
+            {
+                Output.WriteLine($"{nation.N_NATIONKEY}: {nation.N_NAME} (region: {nation.N_REGIONKEY}), {nation.N_COMMENT}");
+            }
+        }
+
+        [Fact]
+        public void ParameterizedQuery()
+        {
+            using var connection = GetConnection();
+            const int region = 1;
+            var nations = connection.Query<Nation>(@"SELECT * FROM NATION WHERE N_REGIONKEY=?region?", new { region }).AsList();
+            Assert.NotEmpty(nations);
+            Output.WriteLine($"nations: {nations.Count}");
+            foreach (var nation in nations)
+            {
+                Output.WriteLine($"{nation.N_NATIONKEY}: {nation.N_NAME} (region: {nation.N_REGIONKEY}), {nation.N_COMMENT}");
+            }
+        }
+
+        public class Nation
+        {
+            public int N_NATIONKEY { get; set; }
+            public string N_NAME{ get; set; }
+            public int N_REGIONKEY { get; set; }
+            public string N_COMMENT { get; set; }
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Snowflake uses positional bind variables (`?`), with the additional nuance that the parameters must be *named* by their position, i.e. `"1"`, `"2"`, etc. Adds support and tests for this. Cross-ref: #1687