### PR TITLE
Add StreamAsync alternatives to support IAsyncEnumerable

### DIFF
--- a/Dapper.StrongName/Dapper.StrongName.csproj
+++ b/Dapper.StrongName/Dapper.StrongName.csproj
@@ -5,7 +5,7 @@
     <Title>Dapper (Strong Named)</Title>
     <Description>A high performance Micro-ORM supporting SQL Server, MySQL, Sqlite, SqlCE, Firebird etc..</Description>
     <Authors>Sam Saffron;Marc Gravell;Nick Craver</Authors>
-    <TargetFrameworks>net461;netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;net5.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
   </PropertyGroup>
@@ -19,6 +19,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
   </ItemGroup>
 </Project>

--- a/Dapper.StrongName/Dapper.StrongName.csproj
+++ b/Dapper.StrongName/Dapper.StrongName.csproj
@@ -5,7 +5,7 @@
     <Title>Dapper (Strong Named)</Title>
     <Description>A high performance Micro-ORM supporting SQL Server, MySQL, Sqlite, SqlCE, Firebird etc..</Description>
     <Authors>Sam Saffron;Marc Gravell;Nick Craver</Authors>
-    <TargetFrameworks>net461;netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
   </PropertyGroup>

--- a/Dapper/Dapper.csproj
+++ b/Dapper/Dapper.csproj
@@ -5,7 +5,7 @@
     <PackageTags>orm;sql;micro-orm</PackageTags>
     <Description>A high performance Micro-ORM supporting SQL Server, MySQL, Sqlite, SqlCE, Firebird etc..</Description>
     <Authors>Sam Saffron;Marc Gravell;Nick Craver</Authors>
-    <TargetFrameworks>net461;netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;net5.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Folder Include="Properties\" />
@@ -16,6 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
   </ItemGroup>
 </Project>

--- a/Dapper/Dapper.csproj
+++ b/Dapper/Dapper.csproj
@@ -5,7 +5,7 @@
     <PackageTags>orm;sql;micro-orm</PackageTags>
     <Description>A high performance Micro-ORM supporting SQL Server, MySQL, Sqlite, SqlCE, Firebird etc..</Description>
     <Authors>Sam Saffron;Marc Gravell;Nick Craver</Authors>
-    <TargetFrameworks>net461;netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/Dapper/SqlMapper.AsyncStream.cs
+++ b/Dapper/SqlMapper.AsyncStream.cs
@@ -1,4 +1,4 @@
-﻿#if NET5_0 || NETSTANDARD2_1
+﻿#if NET5_0 || NETSTANDARD2_0
 using System;
 using System.Collections.Generic;
 using System.Data;
@@ -96,7 +96,10 @@ namespace Dapper
             var info = GetCacheInfo(identity, param, command.AddToCache);
             bool wasClosed = cnn.State == ConnectionState.Closed;
             var cancel = command.CancellationToken;
-            await using var cmd = command.TrySetupAsyncCommand(cnn, info.ParamReader);
+#if NET5_0
+            await
+#endif
+            using var cmd = command.TrySetupAsyncCommand(cnn, info.ParamReader);
             DbDataReader reader = null;
             try
             {
@@ -131,7 +134,10 @@ namespace Dapper
             }
             finally
             {
-                await using (reader) { /* dispose if non-null */ }
+#if NET5_0
+                await
+#endif
+                using (reader) { /* dispose if non-null */ }
                 if (wasClosed) cnn.Close();
             }
         }
@@ -392,8 +398,14 @@ namespace Dapper
             try
             {
                 if (wasClosed) await cnn.TryOpenAsync(command.CancellationToken).ConfigureAwait(false);
-                await using var cmd = command.TrySetupAsyncCommand(cnn, info.ParamReader);
-                await using var reader = await ExecuteReaderWithFlagsFallbackAsync(cmd, wasClosed, CommandBehavior.SequentialAccess | CommandBehavior.SingleResult, cancel).ConfigureAwait(false);
+#if NET5_0
+                await
+#endif
+                using var cmd = command.TrySetupAsyncCommand(cnn, info.ParamReader);
+#if NET5_0
+                await
+#endif
+                using var reader = await ExecuteReaderWithFlagsFallbackAsync(cmd, wasClosed, CommandBehavior.SequentialAccess | CommandBehavior.SingleResult, cancel).ConfigureAwait(false);
                 if (!command.Buffered) wasClosed = false; // handing back open reader; rely on command-behavior
                 var results = MultiMapStreamImpl<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(null, CommandDefinition.ForCallback(command.Parameters), map, splitOn, reader, identity, true);
 
@@ -451,8 +463,14 @@ namespace Dapper
             try
             {
                 if (wasClosed) await cnn.TryOpenAsync(command.CancellationToken).ConfigureAwait(false);
-                await using var cmd = command.TrySetupAsyncCommand(cnn, info.ParamReader);
-                await using var reader = await ExecuteReaderWithFlagsFallbackAsync(cmd, wasClosed, CommandBehavior.SequentialAccess | CommandBehavior.SingleResult, cancel).ConfigureAwait(false);
+#if NET5_0
+                await
+#endif
+                using var cmd = command.TrySetupAsyncCommand(cnn, info.ParamReader);
+#if NET5_0
+                await
+#endif
+                using var reader = await ExecuteReaderWithFlagsFallbackAsync(cmd, wasClosed, CommandBehavior.SequentialAccess | CommandBehavior.SingleResult, cancel).ConfigureAwait(false);
                 var results = MultiMapAsyncImpl(null, default, types, map, splitOn, reader, identity, true);
 
                 var buffer = command.Buffered ? new List<TReturn>() : null;
@@ -523,12 +541,18 @@ namespace Dapper
             {
                 try
                 {
-                    await using (ownedReader) { /* dispose if non-null */ }
+#if NET5_0
+                    await
+#endif
+                    using (ownedReader) { /* dispose if non-null */ }
                 }
                 finally
                 {
                     ownedCommand?.Parameters.Clear();
-                    await using (ownedCommand) { /* dispose if non-null */ }
+#if NET5_0
+                    await
+#endif
+                    using (ownedCommand) { /* dispose if non-null */ }
                     if (wasClosed) cnn.Close();
                 }
             }
@@ -590,16 +614,22 @@ namespace Dapper
             {
                 try
                 {
-                    await using (ownedReader) { /* dispose if non-null */ }
+#if NET5_0
+                    await
+#endif
+                    using (ownedReader) { /* dispose if non-null */ }
                 }
                 finally
                 {
                     ownedCommand?.Parameters.Clear();
-                    await using (ownedCommand) { /* dispose if non-null */ }
+#if NET5_0
+                    await
+#endif
+                    using (ownedCommand) { /* dispose if non-null */ }
                     if (wasClosed) cnn.Close();
                 }
             }
         }
     }
 }
-#endif // NET5_0
+#endif // NET5_0 || NETSTANDARD2_0

--- a/Dapper/SqlMapper.AsyncStream.cs
+++ b/Dapper/SqlMapper.AsyncStream.cs
@@ -1,4 +1,4 @@
-﻿#if NETCOREAPP
+﻿#if NET5_0
 using System;
 using System.Collections.Generic;
 using System.Data;
@@ -602,4 +602,4 @@ namespace Dapper
         }
     }
 }
-#endif
+#endif // NET5_0

--- a/Dapper/SqlMapper.AsyncStream.cs
+++ b/Dapper/SqlMapper.AsyncStream.cs
@@ -1,0 +1,605 @@
+﻿#if NETCOREAPP
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Dapper
+{
+    public static partial class SqlMapper
+    {
+        /// <summary>
+        /// Execute a query using an asynchronous stream.
+        /// </summary>
+        /// <param name="cnn">The connection to query on.</param>
+        /// <param name="sql">The SQL to execute for the query.</param>
+        /// <param name="param">The parameters to pass, if any.</param>
+        /// <param name="transaction">The transaction to use, if any.</param>
+        /// <param name="commandTimeout">The command timeout (in seconds).</param>
+        /// <param name="commandType">The type of command to execute.</param>
+        /// <remarks>Note: each row can be accessed via "dynamic", or by casting to an IDictionary&lt;string,object&gt;</remarks>
+        public static IAsyncEnumerable<dynamic> StreamAsync(this IDbConnection cnn, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
+            StreamAsync<dynamic>(cnn, typeof(DapperRow), new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.None, default));
+
+        /// <summary>
+        /// Execute a query using an asynchronous stream.
+        /// </summary>
+        /// <param name="cnn">The connection to query on.</param>
+        /// <param name="command">The command used to query on this connection.</param>
+        /// <remarks>Note: each row can be accessed via "dynamic", or by casting to an IDictionary&lt;string,object&gt;</remarks>
+        public static IAsyncEnumerable<dynamic> StreamAsync(this IDbConnection cnn, CommandDefinition command) =>
+            StreamAsync<dynamic>(cnn, typeof(DapperRow), command);
+
+        /// <summary>
+        /// Execute a query using an asynchronous stream.
+        /// </summary>
+        /// <typeparam name="T">The type of results to return.</typeparam>
+        /// <param name="cnn">The connection to query on.</param>
+        /// <param name="sql">The SQL to execute for the query.</param>
+        /// <param name="param">The parameters to pass, if any.</param>
+        /// <param name="transaction">The transaction to use, if any.</param>
+        /// <param name="commandTimeout">The command timeout (in seconds).</param>
+        /// <param name="commandType">The type of command to execute.</param>
+        /// <returns>
+        /// A sequence of data of <typeparamref name="T"/>; if a basic type (int, string, etc) is queried then the data from the first column in assumed, otherwise an instance is
+        /// created per row, and a direct column-name===member-name mapping is assumed (case insensitive).
+        /// </returns>
+        public static IAsyncEnumerable<T> StreamAsync<T>(this IDbConnection cnn, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
+            StreamAsync<T>(cnn, typeof(T), new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.None, default));
+
+        /// <summary>
+        /// Execute a query using an asynchronous stream.
+        /// </summary>
+        /// <param name="cnn">The connection to query on.</param>
+        /// <param name="type">The type to return.</param>
+        /// <param name="sql">The SQL to execute for the query.</param>
+        /// <param name="param">The parameters to pass, if any.</param>
+        /// <param name="transaction">The transaction to use, if any.</param>
+        /// <param name="commandTimeout">The command timeout (in seconds).</param>
+        /// <param name="commandType">The type of command to execute.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="type"/> is <c>null</c>.</exception>
+        public static IAsyncEnumerable<object> StreamAsync(this IDbConnection cnn, Type type, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        {
+            if (type == null) throw new ArgumentNullException(nameof(type));
+            return StreamAsync<object>(cnn, type, new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.None, default));
+        }
+
+        /// <summary>
+        /// Execute a query using an asynchronous stream.
+        /// </summary>
+        /// <typeparam name="T">The type to return.</typeparam>
+        /// <param name="cnn">The connection to query on.</param>
+        /// <param name="command">The command used to query on this connection.</param>
+        /// <returns>
+        /// A sequence of data of <typeparamref name="T"/>; if a basic type (int, string, etc) is queried then the data from the first column in assumed, otherwise an instance is
+        /// created per row, and a direct column-name===member-name mapping is assumed (case insensitive).
+        /// </returns>
+        public static IAsyncEnumerable<T> StreamAsync<T>(this IDbConnection cnn, CommandDefinition command) =>
+            StreamAsync<T>(cnn, typeof(T), command);
+
+        /// <summary>
+        /// Execute a query using an asynchronous stream.
+        /// </summary>
+        /// <param name="cnn">The connection to query on.</param>
+        /// <param name="type">The type to return.</param>
+        /// <param name="command">The command used to query on this connection.</param>
+        public static IAsyncEnumerable<object> StreamAsync(this IDbConnection cnn, Type type, CommandDefinition command) =>
+            StreamAsync<object>(cnn, type, command);
+
+        private static async IAsyncEnumerable<T> StreamAsync<T>(this IDbConnection cnn, Type effectiveType, CommandDefinition command)
+        {
+            object param = command.Parameters;
+            var identity = new Identity(command.CommandText, command.CommandType, cnn, effectiveType, param?.GetType());
+            var info = GetCacheInfo(identity, param, command.AddToCache);
+            bool wasClosed = cnn.State == ConnectionState.Closed;
+            var cancel = command.CancellationToken;
+            await using var cmd = command.TrySetupAsyncCommand(cnn, info.ParamReader);
+            DbDataReader reader = null;
+            try
+            {
+                if (wasClosed) await cnn.TryOpenAsync(cancel).ConfigureAwait(false);
+                reader = await ExecuteReaderWithFlagsFallbackAsync(cmd, wasClosed, CommandBehavior.SequentialAccess | CommandBehavior.SingleResult, cancel).ConfigureAwait(false);
+
+                var tuple = info.Deserializer;
+                int hash = GetColumnHash(reader);
+                if (tuple.Func == null || tuple.Hash != hash)
+                {
+                    if (reader.FieldCount == 0)
+                        yield break;
+                    tuple = info.Deserializer = new DeserializerState(hash, GetDeserializer(effectiveType, reader, 0, -1, false));
+                    if (command.AddToCache) SetQueryCache(identity, info);
+                }
+
+                var func = tuple.Func;
+
+                var buffer = command.Buffered ? new List<T>() : null;
+                while (await reader.ReadAsync(cancel).ConfigureAwait(false))
+                {
+                    var val = GetValue<T>(reader, effectiveType, func(reader));
+
+                    if (buffer == null) yield return val;
+                    else buffer.Add(val);
+                }
+                while (await reader.NextResultAsync(cancel).ConfigureAwait(false)) { /* ignore subsequent result sets */ }
+                command.OnCompleted();
+
+                if (buffer == null) yield break;
+                foreach (var result in buffer) yield return result;
+            }
+            finally
+            {
+                await using (reader) { /* dispose if non-null */ }
+                if (wasClosed) cnn.Close();
+            }
+        }
+
+        /// <summary>
+        /// Perform an asynchronous multi-mapping query with 2 input types.
+        /// This returns a single type, combined from the raw types via <paramref name="map"/>.
+        /// </summary>
+        /// <typeparam name="TFirst">The first type in the recordset.</typeparam>
+        /// <typeparam name="TSecond">The second type in the recordset.</typeparam>
+        /// <typeparam name="TReturn">The combined type to return.</typeparam>
+        /// <param name="cnn">The connection to query on.</param>
+        /// <param name="sql">The SQL to execute for this query.</param>
+        /// <param name="map">The function to map row types to the return type.</param>
+        /// <param name="param">The parameters to use for this query.</param>
+        /// <param name="transaction">The transaction to use for this query.</param>
+        /// <param name="buffered">Whether to buffer the results in memory.</param>
+        /// <param name="splitOn">The field we should split and read the second object from (default: "Id").</param>
+        /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
+        /// <param name="commandType">Is it a stored proc or a batch?</param>
+        /// <returns>An asynchronous stream of <typeparamref name="TReturn"/>.</returns>
+        public static IAsyncEnumerable<TReturn> StreamAsync<TFirst, TSecond, TReturn>(this IDbConnection cnn, string sql, Func<TFirst, TSecond, TReturn> map, object param = null, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null) =>
+            MultiMapStreamAsync<TFirst, TSecond, DontMap, DontMap, DontMap, DontMap, DontMap, TReturn>(cnn,
+                new CommandDefinition(sql, param, transaction, commandTimeout, commandType, buffered ? CommandFlags.Buffered : CommandFlags.None, default), map, splitOn);
+
+        /// <summary>
+        /// Perform an asynchronous multi-mapping query with 2 input types.
+        /// This returns a single type, combined from the raw types via <paramref name="map"/>.
+        /// </summary>
+        /// <typeparam name="TFirst">The first type in the recordset.</typeparam>
+        /// <typeparam name="TSecond">The second type in the recordset.</typeparam>
+        /// <typeparam name="TReturn">The combined type to return.</typeparam>
+        /// <param name="cnn">The connection to query on.</param>
+        /// <param name="splitOn">The field we should split and read the second object from (default: "Id").</param>
+        /// <param name="command">The command to execute.</param>
+        /// <param name="map">The function to map row types to the return type.</param>
+        /// <returns>An asynchronous stream of <typeparamref name="TReturn"/>.</returns>
+        public static IAsyncEnumerable<TReturn> StreamAsync<TFirst, TSecond, TReturn>(this IDbConnection cnn, CommandDefinition command, Func<TFirst, TSecond, TReturn> map, string splitOn = "Id") =>
+            MultiMapStreamAsync<TFirst, TSecond, DontMap, DontMap, DontMap, DontMap, DontMap, TReturn>(cnn, command, map, splitOn);
+
+        /// <summary>
+        /// Perform an asynchronous multi-mapping query with 3 input types.
+        /// This returns a single type, combined from the raw types via <paramref name="map"/>.
+        /// </summary>
+        /// <typeparam name="TFirst">The first type in the recordset.</typeparam>
+        /// <typeparam name="TSecond">The second type in the recordset.</typeparam>
+        /// <typeparam name="TThird">The third type in the recordset.</typeparam>
+        /// <typeparam name="TReturn">The combined type to return.</typeparam>
+        /// <param name="cnn">The connection to query on.</param>
+        /// <param name="sql">The SQL to execute for this query.</param>
+        /// <param name="map">The function to map row types to the return type.</param>
+        /// <param name="param">The parameters to use for this query.</param>
+        /// <param name="transaction">The transaction to use for this query.</param>
+        /// <param name="buffered">Whether to buffer the results in memory.</param>
+        /// <param name="splitOn">The field we should split and read the second object from (default: "Id").</param>
+        /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
+        /// <param name="commandType">Is it a stored proc or a batch?</param>
+        /// <returns>An asynchronous stream of <typeparamref name="TReturn"/>.</returns>
+        public static IAsyncEnumerable<TReturn> StreamAsync<TFirst, TSecond, TThird, TReturn>(this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TReturn> map, object param = null, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null) =>
+            MultiMapStreamAsync<TFirst, TSecond, TThird, DontMap, DontMap, DontMap, DontMap, TReturn>(cnn,
+                new CommandDefinition(sql, param, transaction, commandTimeout, commandType, buffered ? CommandFlags.Buffered : CommandFlags.None, default), map, splitOn);
+
+        /// <summary>
+        /// Perform an asynchronous multi-mapping query with 3 input types.
+        /// This returns a single type, combined from the raw types via <paramref name="map"/>.
+        /// </summary>
+        /// <typeparam name="TFirst">The first type in the recordset.</typeparam>
+        /// <typeparam name="TSecond">The second type in the recordset.</typeparam>
+        /// <typeparam name="TThird">The third type in the recordset.</typeparam>
+        /// <typeparam name="TReturn">The combined type to return.</typeparam>
+        /// <param name="cnn">The connection to query on.</param>
+        /// <param name="splitOn">The field we should split and read the second object from (default: "Id").</param>
+        /// <param name="command">The command to execute.</param>
+        /// <param name="map">The function to map row types to the return type.</param>
+        /// <returns>An asynchronous stream of <typeparamref name="TReturn"/>.</returns>
+        public static IAsyncEnumerable<TReturn> StreamAsync<TFirst, TSecond, TThird, TReturn>(this IDbConnection cnn, CommandDefinition command, Func<TFirst, TSecond, TThird, TReturn> map, string splitOn = "Id") =>
+            MultiMapStreamAsync<TFirst, TSecond, TThird, DontMap, DontMap, DontMap, DontMap, TReturn>(cnn, command, map, splitOn);
+
+        /// <summary>
+        /// Perform an asynchronous multi-mapping query with 4 input types.
+        /// This returns a single type, combined from the raw types via <paramref name="map"/>.
+        /// </summary>
+        /// <typeparam name="TFirst">The first type in the recordset.</typeparam>
+        /// <typeparam name="TSecond">The second type in the recordset.</typeparam>
+        /// <typeparam name="TThird">The third type in the recordset.</typeparam>
+        /// <typeparam name="TFourth">The fourth type in the recordset.</typeparam>
+        /// <typeparam name="TReturn">The combined type to return.</typeparam>
+        /// <param name="cnn">The connection to query on.</param>
+        /// <param name="sql">The SQL to execute for this query.</param>
+        /// <param name="map">The function to map row types to the return type.</param>
+        /// <param name="param">The parameters to use for this query.</param>
+        /// <param name="transaction">The transaction to use for this query.</param>
+        /// <param name="buffered">Whether to buffer the results in memory.</param>
+        /// <param name="splitOn">The field we should split and read the second object from (default: "Id").</param>
+        /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
+        /// <param name="commandType">Is it a stored proc or a batch?</param>
+        /// <returns>An asynchronous stream of <typeparamref name="TReturn"/>.</returns>
+        public static IAsyncEnumerable<TReturn> StreamAsync<TFirst, TSecond, TThird, TFourth, TReturn>(this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TFourth, TReturn> map, object param = null, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null) =>
+            MultiMapStreamAsync<TFirst, TSecond, TThird, TFourth, DontMap, DontMap, DontMap, TReturn>(cnn,
+                new CommandDefinition(sql, param, transaction, commandTimeout, commandType, buffered ? CommandFlags.Buffered : CommandFlags.None, default), map, splitOn);
+
+        /// <summary>
+        /// Perform an asynchronous multi-mapping query with 4 input types.
+        /// This returns a single type, combined from the raw types via <paramref name="map"/>.
+        /// </summary>
+        /// <typeparam name="TFirst">The first type in the recordset.</typeparam>
+        /// <typeparam name="TSecond">The second type in the recordset.</typeparam>
+        /// <typeparam name="TThird">The third type in the recordset.</typeparam>
+        /// <typeparam name="TFourth">The fourth type in the recordset.</typeparam>
+        /// <typeparam name="TReturn">The combined type to return.</typeparam>
+        /// <param name="cnn">The connection to query on.</param>
+        /// <param name="splitOn">The field we should split and read the second object from (default: "Id").</param>
+        /// <param name="command">The command to execute.</param>
+        /// <param name="map">The function to map row types to the return type.</param>
+        /// <returns>An asynchronous stream of <typeparamref name="TReturn"/>.</returns>
+        public static IAsyncEnumerable<TReturn> StreamAsync<TFirst, TSecond, TThird, TFourth, TReturn>(this IDbConnection cnn, CommandDefinition command, Func<TFirst, TSecond, TThird, TFourth, TReturn> map, string splitOn = "Id") =>
+            MultiMapStreamAsync<TFirst, TSecond, TThird, TFourth, DontMap, DontMap, DontMap, TReturn>(cnn, command, map, splitOn);
+
+        /// <summary>
+        /// Perform an asynchronous multi-mapping query with 5 input types.
+        /// This returns a single type, combined from the raw types via <paramref name="map"/>.
+        /// </summary>
+        /// <typeparam name="TFirst">The first type in the recordset.</typeparam>
+        /// <typeparam name="TSecond">The second type in the recordset.</typeparam>
+        /// <typeparam name="TThird">The third type in the recordset.</typeparam>
+        /// <typeparam name="TFourth">The fourth type in the recordset.</typeparam>
+        /// <typeparam name="TFifth">The fifth type in the recordset.</typeparam>
+        /// <typeparam name="TReturn">The combined type to return.</typeparam>
+        /// <param name="cnn">The connection to query on.</param>
+        /// <param name="sql">The SQL to execute for this query.</param>
+        /// <param name="map">The function to map row types to the return type.</param>
+        /// <param name="param">The parameters to use for this query.</param>
+        /// <param name="transaction">The transaction to use for this query.</param>
+        /// <param name="buffered">Whether to buffer the results in memory.</param>
+        /// <param name="splitOn">The field we should split and read the second object from (default: "Id").</param>
+        /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
+        /// <param name="commandType">Is it a stored proc or a batch?</param>
+        /// <returns>An asynchronous stream of <typeparamref name="TReturn"/>.</returns>
+        public static IAsyncEnumerable<TReturn> StreamAsync<TFirst, TSecond, TThird, TFourth, TFifth, TReturn>(this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TFourth, TFifth, TReturn> map, object param = null, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null) =>
+            MultiMapStreamAsync<TFirst, TSecond, TThird, TFourth, TFifth, DontMap, DontMap, TReturn>(cnn,
+                new CommandDefinition(sql, param, transaction, commandTimeout, commandType, buffered ? CommandFlags.Buffered : CommandFlags.None, default), map, splitOn);
+
+        /// <summary>
+        /// Perform an asynchronous multi-mapping query with 5 input types.
+        /// This returns a single type, combined from the raw types via <paramref name="map"/>.
+        /// </summary>
+        /// <typeparam name="TFirst">The first type in the recordset.</typeparam>
+        /// <typeparam name="TSecond">The second type in the recordset.</typeparam>
+        /// <typeparam name="TThird">The third type in the recordset.</typeparam>
+        /// <typeparam name="TFourth">The fourth type in the recordset.</typeparam>
+        /// <typeparam name="TFifth">The fifth type in the recordset.</typeparam>
+        /// <typeparam name="TReturn">The combined type to return.</typeparam>
+        /// <param name="cnn">The connection to query on.</param>
+        /// <param name="splitOn">The field we should split and read the second object from (default: "Id").</param>
+        /// <param name="command">The command to execute.</param>
+        /// <param name="map">The function to map row types to the return type.</param>
+        /// <returns>An asynchronous stream of <typeparamref name="TReturn"/>.</returns>
+        public static IAsyncEnumerable<TReturn> StreamAsync<TFirst, TSecond, TThird, TFourth, TFifth, TReturn>(this IDbConnection cnn, CommandDefinition command, Func<TFirst, TSecond, TThird, TFourth, TFifth, TReturn> map, string splitOn = "Id") =>
+            MultiMapStreamAsync<TFirst, TSecond, TThird, TFourth, TFifth, DontMap, DontMap, TReturn>(cnn, command, map, splitOn);
+
+        /// <summary>
+        /// Perform an asynchronous multi-mapping query with 6 input types.
+        /// This returns a single type, combined from the raw types via <paramref name="map"/>.
+        /// </summary>
+        /// <typeparam name="TFirst">The first type in the recordset.</typeparam>
+        /// <typeparam name="TSecond">The second type in the recordset.</typeparam>
+        /// <typeparam name="TThird">The third type in the recordset.</typeparam>
+        /// <typeparam name="TFourth">The fourth type in the recordset.</typeparam>
+        /// <typeparam name="TFifth">The fifth type in the recordset.</typeparam>
+        /// <typeparam name="TSixth">The sixth type in the recordset.</typeparam>
+        /// <typeparam name="TReturn">The combined type to return.</typeparam>
+        /// <param name="cnn">The connection to query on.</param>
+        /// <param name="sql">The SQL to execute for this query.</param>
+        /// <param name="map">The function to map row types to the return type.</param>
+        /// <param name="param">The parameters to use for this query.</param>
+        /// <param name="transaction">The transaction to use for this query.</param>
+        /// <param name="buffered">Whether to buffer the results in memory.</param>
+        /// <param name="splitOn">The field we should split and read the second object from (default: "Id").</param>
+        /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
+        /// <param name="commandType">Is it a stored proc or a batch?</param>
+        /// <returns>An asynchronous stream of <typeparamref name="TReturn"/>.</returns>
+        public static IAsyncEnumerable<TReturn> StreamAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TReturn>(this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TReturn> map, object param = null, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null) =>
+            MultiMapStreamAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, DontMap, TReturn>(cnn,
+                new CommandDefinition(sql, param, transaction, commandTimeout, commandType, buffered ? CommandFlags.Buffered : CommandFlags.None, default), map, splitOn);
+
+        /// <summary>
+        /// Perform an asynchronous multi-mapping query with 6 input types.
+        /// This returns a single type, combined from the raw types via <paramref name="map"/>.
+        /// </summary>
+        /// <typeparam name="TFirst">The first type in the recordset.</typeparam>
+        /// <typeparam name="TSecond">The second type in the recordset.</typeparam>
+        /// <typeparam name="TThird">The third type in the recordset.</typeparam>
+        /// <typeparam name="TFourth">The fourth type in the recordset.</typeparam>
+        /// <typeparam name="TFifth">The fifth type in the recordset.</typeparam>
+        /// <typeparam name="TSixth">The sixth type in the recordset.</typeparam>
+        /// <typeparam name="TReturn">The combined type to return.</typeparam>
+        /// <param name="cnn">The connection to query on.</param>
+        /// <param name="splitOn">The field we should split and read the second object from (default: "Id").</param>
+        /// <param name="command">The command to execute.</param>
+        /// <param name="map">The function to map row types to the return type.</param>
+        /// <returns>An asynchronous stream of <typeparamref name="TReturn"/>.</returns>
+        public static IAsyncEnumerable<TReturn> StreamAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TReturn>(this IDbConnection cnn, CommandDefinition command, Func<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TReturn> map, string splitOn = "Id") =>
+             MultiMapStreamAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, DontMap, TReturn>(cnn, command, map, splitOn);
+
+        /// <summary>
+        /// Perform an asynchronous multi-mapping query with 7 input types.
+        /// This returns a single type, combined from the raw types via <paramref name="map"/>.
+        /// </summary>
+        /// <typeparam name="TFirst">The first type in the recordset.</typeparam>
+        /// <typeparam name="TSecond">The second type in the recordset.</typeparam>
+        /// <typeparam name="TThird">The third type in the recordset.</typeparam>
+        /// <typeparam name="TFourth">The fourth type in the recordset.</typeparam>
+        /// <typeparam name="TFifth">The fifth type in the recordset.</typeparam>
+        /// <typeparam name="TSixth">The sixth type in the recordset.</typeparam>
+        /// <typeparam name="TSeventh">The seventh type in the recordset.</typeparam>
+        /// <typeparam name="TReturn">The combined type to return.</typeparam>
+        /// <param name="cnn">The connection to query on.</param>
+        /// <param name="sql">The SQL to execute for this query.</param>
+        /// <param name="map">The function to map row types to the return type.</param>
+        /// <param name="param">The parameters to use for this query.</param>
+        /// <param name="transaction">The transaction to use for this query.</param>
+        /// <param name="buffered">Whether to buffer the results in memory.</param>
+        /// <param name="splitOn">The field we should split and read the second object from (default: "Id").</param>
+        /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
+        /// <param name="commandType">Is it a stored proc or a batch?</param>
+        /// <returns>An asynchronous stream of <typeparamref name="TReturn"/>.</returns>
+        public static IAsyncEnumerable<TReturn> StreamAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn> map, object param = null, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null) =>
+            MultiMapStreamAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(cnn,
+                new CommandDefinition(sql, param, transaction, commandTimeout, commandType, buffered ? CommandFlags.Buffered : CommandFlags.None, default), map, splitOn);
+
+        /// <summary>
+        /// Perform an asynchronous multi-mapping query with 7 input types.
+        /// This returns a single type, combined from the raw types via <paramref name="map"/>.
+        /// </summary>
+        /// <typeparam name="TFirst">The first type in the recordset.</typeparam>
+        /// <typeparam name="TSecond">The second type in the recordset.</typeparam>
+        /// <typeparam name="TThird">The third type in the recordset.</typeparam>
+        /// <typeparam name="TFourth">The fourth type in the recordset.</typeparam>
+        /// <typeparam name="TFifth">The fifth type in the recordset.</typeparam>
+        /// <typeparam name="TSixth">The sixth type in the recordset.</typeparam>
+        /// <typeparam name="TSeventh">The seventh type in the recordset.</typeparam>
+        /// <typeparam name="TReturn">The combined type to return.</typeparam>
+        /// <param name="cnn">The connection to query on.</param>
+        /// <param name="splitOn">The field we should split and read the second object from (default: "Id").</param>
+        /// <param name="command">The command to execute.</param>
+        /// <param name="map">The function to map row types to the return type.</param>
+        /// <returns>An asynchronous stream of <typeparamref name="TReturn"/>.</returns>
+        public static IAsyncEnumerable<TReturn> StreamAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(this IDbConnection cnn, CommandDefinition command, Func<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn> map, string splitOn = "Id") =>
+            MultiMapStreamAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(cnn, command, map, splitOn);
+
+        private static async IAsyncEnumerable<TReturn> MultiMapStreamAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(this IDbConnection cnn, CommandDefinition command, Delegate map, string splitOn)
+        {
+            object param = command.Parameters;
+            var identity = new Identity<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh>(command.CommandText, command.CommandType, cnn, typeof(TFirst), param?.GetType());
+            var info = GetCacheInfo(identity, param, command.AddToCache);
+            bool wasClosed = cnn.State == ConnectionState.Closed;
+            CancellationToken cancel = command.CancellationToken;
+            try
+            {
+                if (wasClosed) await cnn.TryOpenAsync(command.CancellationToken).ConfigureAwait(false);
+                await using var cmd = command.TrySetupAsyncCommand(cnn, info.ParamReader);
+                await using var reader = await ExecuteReaderWithFlagsFallbackAsync(cmd, wasClosed, CommandBehavior.SequentialAccess | CommandBehavior.SingleResult, cancel).ConfigureAwait(false);
+                if (!command.Buffered) wasClosed = false; // handing back open reader; rely on command-behavior
+                var results = MultiMapStreamImpl<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(null, CommandDefinition.ForCallback(command.Parameters), map, splitOn, reader, identity, true);
+
+                var buffer = command.Buffered ? new List<TReturn>() : null;
+
+                await foreach (var result in results.WithCancellation(cancel).ConfigureAwait(false))
+                {
+                    if (buffer != null) buffer.Add(result);
+                    else yield return result;
+                }
+
+                if (buffer == null) yield break;
+                foreach (var result in buffer) yield return result;
+            }
+            finally
+            {
+                if (wasClosed) cnn.Close();
+            }
+        }
+
+        /// <summary>
+        /// Perform an asynchronous multi-mapping query with an arbitrary number of input types.
+        /// This returns a single type, combined from the raw types via <paramref name="map"/>.
+        /// </summary>
+        /// <typeparam name="TReturn">The combined type to return.</typeparam>
+        /// <param name="cnn">The connection to query on.</param>
+        /// <param name="sql">The SQL to execute for this query.</param>
+        /// <param name="types">Array of types in the recordset.</param>
+        /// <param name="map">The function to map row types to the return type.</param>
+        /// <param name="param">The parameters to use for this query.</param>
+        /// <param name="transaction">The transaction to use for this query.</param>
+        /// <param name="buffered">Whether to buffer the results in memory.</param>
+        /// <param name="splitOn">The field we should split and read the second object from (default: "Id").</param>
+        /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
+        /// <param name="commandType">Is it a stored proc or a batch?</param>
+        /// <returns>An asynchronous stream of <typeparamref name="TReturn"/>.</returns>
+        public static IAsyncEnumerable<TReturn> StreamAsync<TReturn>(this IDbConnection cnn, string sql, Type[] types, Func<object[], TReturn> map, object param = null, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
+        {
+            var command = new CommandDefinition(sql, param, transaction, commandTimeout, commandType, buffered ? CommandFlags.Buffered : CommandFlags.None, default);
+            return MultiMapStreamAsync(cnn, command, types, map, splitOn);
+        }
+
+        private static async IAsyncEnumerable<TReturn> MultiMapStreamAsync<TReturn>(this IDbConnection cnn, CommandDefinition command, Type[] types, Func<object[], TReturn> map, string splitOn)
+        {
+            if (types.Length < 1)
+            {
+                throw new ArgumentException("you must provide at least one type to deserialize");
+            }
+
+            object param = command.Parameters;
+            var identity = new IdentityWithTypes(command.CommandText, command.CommandType, cnn, types[0], param?.GetType(), types);
+            var info = GetCacheInfo(identity, param, command.AddToCache);
+            bool wasClosed = cnn.State == ConnectionState.Closed;
+            CancellationToken cancel = command.CancellationToken;
+            try
+            {
+                if (wasClosed) await cnn.TryOpenAsync(command.CancellationToken).ConfigureAwait(false);
+                await using var cmd = command.TrySetupAsyncCommand(cnn, info.ParamReader);
+                await using var reader = await ExecuteReaderWithFlagsFallbackAsync(cmd, wasClosed, CommandBehavior.SequentialAccess | CommandBehavior.SingleResult, cancel).ConfigureAwait(false);
+                var results = MultiMapAsyncImpl(null, default, types, map, splitOn, reader, identity, true);
+
+                var buffer = command.Buffered ? new List<TReturn>() : null;
+
+                await foreach (var result in results.WithCancellation(cancel).ConfigureAwait(false))
+                {
+                    if (buffer != null) buffer.Add(result);
+                    else yield return result;
+                }
+
+                if (buffer == null) yield break;
+                foreach (var result in buffer) yield return result;
+            }
+            finally
+            {
+                if (wasClosed) cnn.Close();
+            }
+        }
+
+        private static async IAsyncEnumerable<TReturn> MultiMapStreamImpl<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(this IDbConnection cnn, CommandDefinition command, Delegate map, string splitOn, DbDataReader reader, Identity identity, bool finalize)
+        {
+            object param = command.Parameters;
+            identity ??= new Identity<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh>(command.CommandText, command.CommandType, cnn, typeof(TFirst), param?.GetType());
+            CacheInfo cinfo = GetCacheInfo(identity, param, command.AddToCache);
+            CancellationToken cancel = command.CancellationToken;
+
+            DbCommand ownedCommand = null;
+            DbDataReader ownedReader = null;
+
+            bool wasClosed = cnn?.State == ConnectionState.Closed;
+            try
+            {
+                if (reader == null)
+                {
+                    ownedCommand = command.TrySetupAsyncCommand(cnn, cinfo.ParamReader);
+                    if (wasClosed) cnn.Open();
+                    ownedReader = await ExecuteReaderWithFlagsFallbackAsync(ownedCommand, wasClosed, CommandBehavior.SequentialAccess | CommandBehavior.SingleResult, cancel).ConfigureAwait(false);
+                    reader = ownedReader;
+                }
+                var deserializer = default(DeserializerState);
+                Func<IDataReader, object>[] otherDeserializers;
+
+                int hash = GetColumnHash(reader);
+                if ((deserializer = cinfo.Deserializer).Func == null || (otherDeserializers = cinfo.OtherDeserializers) == null || hash != deserializer.Hash)
+                {
+                    var deserializers = GenerateDeserializers(identity, splitOn, reader);
+                    deserializer = cinfo.Deserializer = new DeserializerState(hash, deserializers[0]);
+                    otherDeserializers = cinfo.OtherDeserializers = deserializers.Skip(1).ToArray();
+                    if (command.AddToCache) SetQueryCache(identity, cinfo);
+                }
+
+                Func<IDataReader, TReturn> mapIt = GenerateMapper<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(deserializer.Func, otherDeserializers, map);
+
+                if (mapIt != null)
+                {
+                    while (await reader.ReadAsync(cancel).ConfigureAwait(false))
+                    {
+                        yield return mapIt(reader);
+                    }
+                    if (finalize)
+                    {
+                        while (await reader.NextResultAsync(cancel).ConfigureAwait(false)) { /* ignore remaining result sets */ }
+                        command.OnCompleted();
+                    }
+                }
+            }
+            finally
+            {
+                try
+                {
+                    await using (ownedReader) { /* dispose if non-null */ }
+                }
+                finally
+                {
+                    ownedCommand?.Parameters.Clear();
+                    await using (ownedCommand) { /* dispose if non-null */ }
+                    if (wasClosed) cnn.Close();
+                }
+            }
+        }
+
+        private static async IAsyncEnumerable<TReturn> MultiMapAsyncImpl<TReturn>(this IDbConnection cnn, CommandDefinition command, Type[] types, Func<object[], TReturn> map, string splitOn, DbDataReader reader, Identity identity, bool finalize)
+        {
+            if (types.Length < 1)
+            {
+                throw new ArgumentException("you must provide at least one type to deserialize");
+            }
+
+            object param = command.Parameters;
+            identity ??= new IdentityWithTypes(command.CommandText, command.CommandType, cnn, types[0], param?.GetType(), types);
+            CacheInfo cinfo = GetCacheInfo(identity, param, command.AddToCache);
+            CancellationToken cancel = command.CancellationToken;
+
+            DbCommand ownedCommand = null;
+            DbDataReader ownedReader = null;
+
+            bool wasClosed = cnn?.State == ConnectionState.Closed;
+            try
+            {
+                if (reader == null)
+                {
+                    ownedCommand = command.TrySetupAsyncCommand(cnn, cinfo.ParamReader);
+                    if (wasClosed) cnn.Open();
+                    ownedReader = await ExecuteReaderWithFlagsFallbackAsync(ownedCommand, wasClosed, CommandBehavior.SequentialAccess | CommandBehavior.SingleResult, cancel).ConfigureAwait(false);
+                    reader = ownedReader;
+                }
+                DeserializerState deserializer;
+                Func<IDataReader, object>[] otherDeserializers;
+
+                int hash = GetColumnHash(reader);
+                if ((deserializer = cinfo.Deserializer).Func == null || (otherDeserializers = cinfo.OtherDeserializers) == null || hash != deserializer.Hash)
+                {
+                    var deserializers = GenerateDeserializers(identity, splitOn, reader);
+                    deserializer = cinfo.Deserializer = new DeserializerState(hash, deserializers[0]);
+                    otherDeserializers = cinfo.OtherDeserializers = deserializers.Skip(1).ToArray();
+                    SetQueryCache(identity, cinfo);
+                }
+
+                Func<IDataReader, TReturn> mapIt = GenerateMapper(types.Length, deserializer.Func, otherDeserializers, map);
+
+                if (mapIt != null)
+                {
+                    while (await reader.ReadAsync(cancel).ConfigureAwait(false))
+                    {
+                        yield return mapIt(reader);
+                    }
+                    if (finalize)
+                    {
+                        while (await reader.NextResultAsync(cancel).ConfigureAwait(false)) { /* ignore remaining result sets */ }
+                        command.OnCompleted();
+                    }
+                }
+            }
+            finally
+            {
+                try
+                {
+                    await using (ownedReader) { /* dispose if non-null */ }
+                }
+                finally
+                {
+                    ownedCommand?.Parameters.Clear();
+                    await using (ownedCommand) { /* dispose if non-null */ }
+                    if (wasClosed) cnn.Close();
+                }
+            }
+        }
+    }
+}
+#endif

--- a/Dapper/SqlMapper.AsyncStream.cs
+++ b/Dapper/SqlMapper.AsyncStream.cs
@@ -20,9 +20,10 @@ namespace Dapper
         /// <param name="transaction">The transaction to use, if any.</param>
         /// <param name="commandTimeout">The command timeout (in seconds).</param>
         /// <param name="commandType">The type of command to execute.</param>
+        /// <param name="cancellationToken">The cancellation token for this query.</param>
         /// <remarks>Note: each row can be accessed via "dynamic", or by casting to an IDictionary&lt;string,object&gt;</remarks>
-        public static IAsyncEnumerable<dynamic> StreamAsync(this IDbConnection cnn, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
-            StreamAsync<dynamic>(cnn, typeof(DapperRow), new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.None, default));
+        public static IAsyncEnumerable<dynamic> StreamAsync(this IDbConnection cnn, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default) =>
+            StreamAsync<dynamic>(cnn, typeof(DapperRow), new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.None, cancellationToken));
 
         /// <summary>
         /// Execute a query using an asynchronous stream.
@@ -43,12 +44,13 @@ namespace Dapper
         /// <param name="transaction">The transaction to use, if any.</param>
         /// <param name="commandTimeout">The command timeout (in seconds).</param>
         /// <param name="commandType">The type of command to execute.</param>
+        /// <param name="cancellationToken">The cancellation token for this query.</param>
         /// <returns>
         /// A sequence of data of <typeparamref name="T"/>; if a basic type (int, string, etc) is queried then the data from the first column in assumed, otherwise an instance is
         /// created per row, and a direct column-name===member-name mapping is assumed (case insensitive).
         /// </returns>
-        public static IAsyncEnumerable<T> StreamAsync<T>(this IDbConnection cnn, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
-            StreamAsync<T>(cnn, typeof(T), new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.None, default));
+        public static IAsyncEnumerable<T> StreamAsync<T>(this IDbConnection cnn, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default) =>
+            StreamAsync<T>(cnn, typeof(T), new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.None, cancellationToken));
 
         /// <summary>
         /// Execute a query using an asynchronous stream.
@@ -60,11 +62,12 @@ namespace Dapper
         /// <param name="transaction">The transaction to use, if any.</param>
         /// <param name="commandTimeout">The command timeout (in seconds).</param>
         /// <param name="commandType">The type of command to execute.</param>
+        /// <param name="cancellationToken">The cancellation token for this query.</param>
         /// <exception cref="ArgumentNullException"><paramref name="type"/> is <c>null</c>.</exception>
-        public static IAsyncEnumerable<object> StreamAsync(this IDbConnection cnn, Type type, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static IAsyncEnumerable<object> StreamAsync(this IDbConnection cnn, Type type, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
             if (type == null) throw new ArgumentNullException(nameof(type));
-            return StreamAsync<object>(cnn, type, new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.None, default));
+            return StreamAsync<object>(cnn, type, new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.None, cancellationToken));
         }
 
         /// <summary>
@@ -158,10 +161,11 @@ namespace Dapper
         /// <param name="splitOn">The field we should split and read the second object from (default: "Id").</param>
         /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
         /// <param name="commandType">Is it a stored proc or a batch?</param>
+        /// <param name="cancellationToken">The cancellation token for this query.</param>
         /// <returns>An asynchronous stream of <typeparamref name="TReturn"/>.</returns>
-        public static IAsyncEnumerable<TReturn> StreamAsync<TFirst, TSecond, TReturn>(this IDbConnection cnn, string sql, Func<TFirst, TSecond, TReturn> map, object param = null, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null) =>
+        public static IAsyncEnumerable<TReturn> StreamAsync<TFirst, TSecond, TReturn>(this IDbConnection cnn, string sql, Func<TFirst, TSecond, TReturn> map, object param = null, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default) =>
             MultiMapStreamAsync<TFirst, TSecond, DontMap, DontMap, DontMap, DontMap, DontMap, TReturn>(cnn,
-                new CommandDefinition(sql, param, transaction, commandTimeout, commandType, buffered ? CommandFlags.Buffered : CommandFlags.None, default), map, splitOn);
+                new CommandDefinition(sql, param, transaction, commandTimeout, commandType, buffered ? CommandFlags.Buffered : CommandFlags.None, cancellationToken), map, splitOn);
 
         /// <summary>
         /// Perform an asynchronous multi-mapping query with 2 input types.
@@ -195,10 +199,11 @@ namespace Dapper
         /// <param name="splitOn">The field we should split and read the second object from (default: "Id").</param>
         /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
         /// <param name="commandType">Is it a stored proc or a batch?</param>
+        /// <param name="cancellationToken">The cancellation token for this query.</param>
         /// <returns>An asynchronous stream of <typeparamref name="TReturn"/>.</returns>
-        public static IAsyncEnumerable<TReturn> StreamAsync<TFirst, TSecond, TThird, TReturn>(this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TReturn> map, object param = null, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null) =>
+        public static IAsyncEnumerable<TReturn> StreamAsync<TFirst, TSecond, TThird, TReturn>(this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TReturn> map, object param = null, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default) =>
             MultiMapStreamAsync<TFirst, TSecond, TThird, DontMap, DontMap, DontMap, DontMap, TReturn>(cnn,
-                new CommandDefinition(sql, param, transaction, commandTimeout, commandType, buffered ? CommandFlags.Buffered : CommandFlags.None, default), map, splitOn);
+                new CommandDefinition(sql, param, transaction, commandTimeout, commandType, buffered ? CommandFlags.Buffered : CommandFlags.None, cancellationToken), map, splitOn);
 
         /// <summary>
         /// Perform an asynchronous multi-mapping query with 3 input types.
@@ -234,10 +239,11 @@ namespace Dapper
         /// <param name="splitOn">The field we should split and read the second object from (default: "Id").</param>
         /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
         /// <param name="commandType">Is it a stored proc or a batch?</param>
+        /// <param name="cancellationToken">The cancellation token for this query.</param>
         /// <returns>An asynchronous stream of <typeparamref name="TReturn"/>.</returns>
-        public static IAsyncEnumerable<TReturn> StreamAsync<TFirst, TSecond, TThird, TFourth, TReturn>(this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TFourth, TReturn> map, object param = null, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null) =>
+        public static IAsyncEnumerable<TReturn> StreamAsync<TFirst, TSecond, TThird, TFourth, TReturn>(this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TFourth, TReturn> map, object param = null, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default) =>
             MultiMapStreamAsync<TFirst, TSecond, TThird, TFourth, DontMap, DontMap, DontMap, TReturn>(cnn,
-                new CommandDefinition(sql, param, transaction, commandTimeout, commandType, buffered ? CommandFlags.Buffered : CommandFlags.None, default), map, splitOn);
+                new CommandDefinition(sql, param, transaction, commandTimeout, commandType, buffered ? CommandFlags.Buffered : CommandFlags.None, cancellationToken), map, splitOn);
 
         /// <summary>
         /// Perform an asynchronous multi-mapping query with 4 input types.
@@ -275,10 +281,11 @@ namespace Dapper
         /// <param name="splitOn">The field we should split and read the second object from (default: "Id").</param>
         /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
         /// <param name="commandType">Is it a stored proc or a batch?</param>
+        /// <param name="cancellationToken">The cancellation token for this query.</param>
         /// <returns>An asynchronous stream of <typeparamref name="TReturn"/>.</returns>
-        public static IAsyncEnumerable<TReturn> StreamAsync<TFirst, TSecond, TThird, TFourth, TFifth, TReturn>(this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TFourth, TFifth, TReturn> map, object param = null, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null) =>
+        public static IAsyncEnumerable<TReturn> StreamAsync<TFirst, TSecond, TThird, TFourth, TFifth, TReturn>(this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TFourth, TFifth, TReturn> map, object param = null, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default) =>
             MultiMapStreamAsync<TFirst, TSecond, TThird, TFourth, TFifth, DontMap, DontMap, TReturn>(cnn,
-                new CommandDefinition(sql, param, transaction, commandTimeout, commandType, buffered ? CommandFlags.Buffered : CommandFlags.None, default), map, splitOn);
+                new CommandDefinition(sql, param, transaction, commandTimeout, commandType, buffered ? CommandFlags.Buffered : CommandFlags.None, cancellationToken), map, splitOn);
 
         /// <summary>
         /// Perform an asynchronous multi-mapping query with 5 input types.
@@ -318,10 +325,11 @@ namespace Dapper
         /// <param name="splitOn">The field we should split and read the second object from (default: "Id").</param>
         /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
         /// <param name="commandType">Is it a stored proc or a batch?</param>
+        /// <param name="cancellationToken">The cancellation token for this query.</param>
         /// <returns>An asynchronous stream of <typeparamref name="TReturn"/>.</returns>
-        public static IAsyncEnumerable<TReturn> StreamAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TReturn>(this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TReturn> map, object param = null, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null) =>
+        public static IAsyncEnumerable<TReturn> StreamAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TReturn>(this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TReturn> map, object param = null, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default) =>
             MultiMapStreamAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, DontMap, TReturn>(cnn,
-                new CommandDefinition(sql, param, transaction, commandTimeout, commandType, buffered ? CommandFlags.Buffered : CommandFlags.None, default), map, splitOn);
+                new CommandDefinition(sql, param, transaction, commandTimeout, commandType, buffered ? CommandFlags.Buffered : CommandFlags.None, cancellationToken), map, splitOn);
 
         /// <summary>
         /// Perform an asynchronous multi-mapping query with 6 input types.
@@ -363,10 +371,11 @@ namespace Dapper
         /// <param name="splitOn">The field we should split and read the second object from (default: "Id").</param>
         /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
         /// <param name="commandType">Is it a stored proc or a batch?</param>
+        /// <param name="cancellationToken">The cancellation token for this query.</param>
         /// <returns>An asynchronous stream of <typeparamref name="TReturn"/>.</returns>
-        public static IAsyncEnumerable<TReturn> StreamAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn> map, object param = null, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null) =>
+        public static IAsyncEnumerable<TReturn> StreamAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn> map, object param = null, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default) =>
             MultiMapStreamAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(cnn,
-                new CommandDefinition(sql, param, transaction, commandTimeout, commandType, buffered ? CommandFlags.Buffered : CommandFlags.None, default), map, splitOn);
+                new CommandDefinition(sql, param, transaction, commandTimeout, commandType, buffered ? CommandFlags.Buffered : CommandFlags.None, cancellationToken), map, splitOn);
 
         /// <summary>
         /// Perform an asynchronous multi-mapping query with 7 input types.
@@ -441,10 +450,11 @@ namespace Dapper
         /// <param name="splitOn">The field we should split and read the second object from (default: "Id").</param>
         /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
         /// <param name="commandType">Is it a stored proc or a batch?</param>
+        /// <param name="cancellationToken">The cancellation token for this query.</param>
         /// <returns>An asynchronous stream of <typeparamref name="TReturn"/>.</returns>
-        public static IAsyncEnumerable<TReturn> StreamAsync<TReturn>(this IDbConnection cnn, string sql, Type[] types, Func<object[], TReturn> map, object param = null, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
+        public static IAsyncEnumerable<TReturn> StreamAsync<TReturn>(this IDbConnection cnn, string sql, Type[] types, Func<object[], TReturn> map, object param = null, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
-            var command = new CommandDefinition(sql, param, transaction, commandTimeout, commandType, buffered ? CommandFlags.Buffered : CommandFlags.None, default);
+            var command = new CommandDefinition(sql, param, transaction, commandTimeout, commandType, buffered ? CommandFlags.Buffered : CommandFlags.None, cancellationToken);
             return MultiMapStreamAsync(cnn, command, types, map, splitOn);
         }
 
@@ -462,7 +472,7 @@ namespace Dapper
             CancellationToken cancel = command.CancellationToken;
             try
             {
-                if (wasClosed) await cnn.TryOpenAsync(command.CancellationToken).ConfigureAwait(false);
+                if (wasClosed) await cnn.TryOpenAsync(cancel).ConfigureAwait(false);
 #if NET5_0
                 await
 #endif

--- a/Dapper/SqlMapper.AsyncStream.cs
+++ b/Dapper/SqlMapper.AsyncStream.cs
@@ -1,4 +1,4 @@
-﻿#if NET5_0
+﻿#if NET5_0 || NETSTANDARD2_1
 using System;
 using System.Collections.Generic;
 using System.Data;

--- a/Dapper/SqlMapper.GridReader.AsyncStream.cs
+++ b/Dapper/SqlMapper.GridReader.AsyncStream.cs
@@ -1,0 +1,100 @@
+﻿#if NETCOREAPP
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Dapper
+{
+    public static partial class SqlMapper
+    {
+        public partial class GridReader
+        {
+            /// <summary>
+            /// Read the next grid of results, returned as a dynamic object
+            /// </summary>
+            /// <remarks>Note: each row can be accessed via "dynamic", or by casting to an IDictionary&lt;string,object&gt;</remarks>
+            /// <param name="buffered">Whether to buffer the results.</param>
+            public IAsyncEnumerable<dynamic> StreamAsync(bool buffered = false) => StreamAsyncImpl<dynamic>(typeof(DapperRow), buffered);
+
+            /// <summary>
+            /// Read the next grid of results
+            /// </summary>
+            /// <param name="type">The type to read.</param>
+            /// <param name="buffered">Whether to buffer the results.</param>
+            /// <exception cref="ArgumentNullException"><paramref name="type"/> is <c>null</c>.</exception>
+            public IAsyncEnumerable<object> StreamAsync(Type type, bool buffered = false)
+            {
+                if (type == null) throw new ArgumentNullException(nameof(type));
+                return StreamAsyncImpl<object>(type, buffered);
+            }
+
+            /// <summary>
+            /// Read the next grid of results.
+            /// </summary>
+            /// <typeparam name="T">The type to read.</typeparam>
+            /// <param name="buffered">Whether the results should be buffered in memory.</param>
+            public IAsyncEnumerable<T> StreamAsync<T>(bool buffered = false) => StreamAsyncImpl<T>(typeof(T), buffered);
+
+            private async IAsyncEnumerable<T> StreamAsyncImpl<T>(Type type, bool buffered)
+            {
+                if (reader == null) throw new ObjectDisposedException(GetType().FullName, "The reader has been disposed; this can happen after all data has been consumed");
+                if (IsConsumed) throw new InvalidOperationException("Query results must be consumed in the correct order, and each result can only be consumed once");
+                var typedIdentity = identity.ForGrid(type, gridIndex);
+                CacheInfo cache = GetCacheInfo(typedIdentity, null, addToCache);
+                var deserializer = cache.Deserializer;
+
+                int hash = GetColumnHash(reader);
+                if (deserializer.Func == null || deserializer.Hash != hash)
+                {
+                    deserializer = new DeserializerState(hash, GetDeserializer(type, reader, 0, -1, false));
+                    cache.Deserializer = deserializer;
+                }
+                IsConsumed = true;
+                if (reader is DbDataReader)
+                {
+                    var buffer = buffered ? new List<T>() : null;
+
+                    await foreach (var value in ReadStreamAsync<T>(gridIndex, deserializer.Func).WithCancellation(cancel).ConfigureAwait(false))
+                    {
+                        if (buffer != null) buffer.Add(value);
+                        else yield return value;
+                    }
+
+                    if (buffer == null) yield break;
+                    foreach (var value in buffer) yield return value;
+                }
+                else
+                {
+                    var result = ReadDeferred<T>(gridIndex, deserializer.Func, type);
+                    if (buffered) result = result?.ToList(); // for the "not a DbDataReader" scenario
+
+                    if(result == null) yield break;
+                    foreach (var value in result) yield return value;
+                }
+            }
+
+            private async IAsyncEnumerable<T> ReadStreamAsync<T>(int index, Func<IDataReader, object> deserializer)
+            {
+                try
+                {
+                    var dbReader = (DbDataReader)this.reader;
+                    while (index == gridIndex && await dbReader.ReadAsync(cancel).ConfigureAwait(false))
+                    {
+                        yield return ConvertTo<T>(deserializer(dbReader));
+                    }
+                }
+                finally // finally so that First etc progresses things even when multiple rows
+                {
+                    if (index == gridIndex)
+                    {
+                        await NextResultAsync().ConfigureAwait(false);
+                    }
+                }
+            }
+        }
+    }
+}
+#endif // NETCOREAPP

--- a/Dapper/SqlMapper.GridReader.AsyncStream.cs
+++ b/Dapper/SqlMapper.GridReader.AsyncStream.cs
@@ -1,4 +1,4 @@
-﻿#if NETCOREAPP
+﻿#if NET5_0 || NETSTANDARD2_1
 using System;
 using System.Collections.Generic;
 using System.Data;
@@ -97,4 +97,4 @@ namespace Dapper
         }
     }
 }
-#endif // NETCOREAPP
+#endif // NET5_0 || NETSTANDARD2_1

--- a/Dapper/SqlMapper.GridReader.AsyncStream.cs
+++ b/Dapper/SqlMapper.GridReader.AsyncStream.cs
@@ -1,4 +1,4 @@
-﻿#if NET5_0 || NETSTANDARD2_1
+﻿#if NET5_0 || NETSTANDARD2_0
 using System;
 using System.Collections.Generic;
 using System.Data;
@@ -97,4 +97,4 @@ namespace Dapper
         }
     }
 }
-#endif // NET5_0 || NETSTANDARD2_1
+#endif // NET5_0 || NETSTANDARD2_0

--- a/tests/Dapper.Tests/AsyncStreamTests.cs
+++ b/tests/Dapper.Tests/AsyncStreamTests.cs
@@ -1,0 +1,551 @@
+﻿#if NET5_0 || NETCOREAPP3_1
+using System.Linq;
+using System.Data;
+using System.Diagnostics;
+using System;
+using System.Threading.Tasks;
+using System.Threading;
+using Xunit;
+using System.Data.Common;
+using System.Linq;
+using Xunit.Abstractions;
+
+namespace Dapper.Tests
+{
+    [Collection(NonParallelDefinition.Name)]
+    public sealed class SystemSqlClientAsyncStreamTests : AsyncStreamTests<SystemSqlClientProvider> { }
+#if MSSQLCLIENT
+    [Collection(NonParallelDefinition.Name)]
+    public sealed class MicrosoftSqlClientAsyncStreamTests : AsyncStreamTests<MicrosoftSqlClientProvider> { }
+#endif
+
+    public abstract class AsyncStreamTests<TProvider> : TestBase<TProvider> where TProvider : SqlServerDatabaseProvider
+    {
+        private DbConnection _marsConnection;
+
+        private DbConnection MarsConnection => _marsConnection ??= Provider.GetOpenConnection(true);
+
+        [Fact]
+        public async Task TestBasicStringUsageAsync()
+        {
+            var query = connection.StreamAsync<string>("select 'abc' as [Value] union all select @txt", new { txt = "def" });
+            var arr = await query.ToListAsync().ConfigureAwait(false);
+            Assert.Equal(new[] { "abc", "def" }, arr);
+        }
+
+        [Fact]
+        public async Task TestBasicStringUsageAsyncNonBuffered()
+        {
+            var query = connection.StreamAsync<string>(new CommandDefinition("select 'abc' as [Value] union all select @txt", new { txt = "def" }, flags: CommandFlags.None));
+            var arr = await query.ToArrayAsync().ConfigureAwait(false);
+            Assert.Equal(new[] { "abc", "def" }, arr);
+        }
+
+        [Fact]
+        public async Task TestLongOperationWithCancellation()
+        {
+            CancellationTokenSource cancel = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            var task = connection.StreamAsync<int>(new CommandDefinition("waitfor delay '00:00:10';select 1", cancellationToken: cancel.Token)).ToListAsync().AsTask();
+            try
+            {
+                if (!task.Wait(TimeSpan.FromSeconds(7)))
+                {
+                    throw new TimeoutException(); // should have cancelled
+                }
+            }
+            catch (AggregateException agg)
+            {
+                Assert.True(agg.InnerException.GetType().Name == "SqlException");
+            }
+        }
+
+        [Fact]
+        public async Task TestBasicStringUsageClosedAsync()
+        {
+            using (var conn = GetClosedConnection())
+            {
+                var query = conn.StreamAsync<string>("select 'abc' as [Value] union all select @txt", new { txt = "def" });
+                var arr = await query.ToArrayAsync().ConfigureAwait(false);
+                Assert.Equal(new[] { "abc", "def" }, arr);
+            }
+        }
+
+        [Fact]
+        public async Task TestQueryDynamicAsync()
+        {
+            var row = await connection.StreamAsync("select 'abc' as [Value]").SingleAsync().ConfigureAwait(false);
+            string value = row.Value;
+            Assert.Equal("abc", value);
+        }
+
+        [Fact]
+        public async Task TestClassWithStringUsageAsync()
+        {
+            var query = connection.StreamAsync<BasicType>("select 'abc' as [Value] union all select @txt", new { txt = "def" });
+            var arr = await query.ToArrayAsync().ConfigureAwait(false);
+            Assert.Equal(new[] { "abc", "def" }, arr.Select(x => x.Value));
+        }
+
+        [Fact]
+        public async Task TestMultiMapWithSplitAsync()
+        {
+            const string sql = "select 1 as id, 'abc' as name, 2 as id, 'def' as name";
+            var productQuery = connection.StreamAsync<Product, Category, Product>(sql, (prod, cat) =>
+            {
+                prod.Category = cat;
+                return prod;
+            });
+
+            var product = await productQuery.FirstAsync().ConfigureAwait(false);
+            // assertions
+            Assert.Equal(1, product.Id);
+            Assert.Equal("abc", product.Name);
+            Assert.Equal(2, product.Category.Id);
+            Assert.Equal("def", product.Category.Name);
+        }
+
+        [Fact]
+        public async Task TestMultiMapArbitraryWithSplitAsync()
+        {
+            const string sql = "select 1 as id, 'abc' as name, 2 as id, 'def' as name";
+            var productQuery = connection.StreamAsync<Product>(sql, new[] { typeof(Product), typeof(Category) }, (objects) =>
+            {
+                var prod = (Product)objects[0];
+                prod.Category = (Category)objects[1];
+                return prod;
+            });
+
+            var product = await productQuery.FirstAsync().ConfigureAwait(false);
+            // assertions
+            Assert.Equal(1, product.Id);
+            Assert.Equal("abc", product.Name);
+            Assert.Equal(2, product.Category.Id);
+            Assert.Equal("def", product.Category.Name);
+        }
+
+        [Fact]
+        public async Task TestMultiMapWithSplitClosedConnAsync()
+        {
+            const string sql = "select 1 as id, 'abc' as name, 2 as id, 'def' as name";
+            using (var conn = GetClosedConnection())
+            {
+                var productQuery = conn.StreamAsync<Product, Category, Product>(sql, (prod, cat) =>
+                {
+                    prod.Category = cat;
+                    return prod;
+                });
+
+                var product = await productQuery.FirstAsync().ConfigureAwait(false);
+                // assertions
+                Assert.Equal(1, product.Id);
+                Assert.Equal("abc", product.Name);
+                Assert.Equal(2, product.Category.Id);
+                Assert.Equal("def", product.Category.Name);
+            }
+        }
+
+        [Fact]
+        public async Task TestMultiAsync()
+        {
+            using (SqlMapper.GridReader multi = await connection.QueryMultipleAsync("select 1; select 2").ConfigureAwait(false))
+            {
+                Assert.Equal(1, multi.StreamAsync<int>().SingleAsync().Result);
+                Assert.Equal(2, multi.StreamAsync<int>().SingleAsync().Result);
+            }
+        }
+
+        [Fact]
+        public async Task TestMultiConversionAsync()
+        {
+            using (SqlMapper.GridReader multi = await connection.QueryMultipleAsync("select Cast(1 as BigInt) Col1; select Cast(2 as BigInt) Col2").ConfigureAwait(false))
+            {
+                Assert.Equal(1, multi.StreamAsync<int>().SingleAsync().Result);
+                Assert.Equal(2, multi.StreamAsync<int>().SingleAsync().Result);
+            }
+        }
+
+        [Fact]
+        public async Task TestMultiAsyncViaFirstOrDefault()
+        {
+            using (SqlMapper.GridReader multi = await connection.QueryMultipleAsync("select 1; select 2; select 3; select 4; select 5").ConfigureAwait(false))
+            {
+                Assert.Equal(1, multi.ReadFirstOrDefaultAsync<int>().Result);
+                Assert.Equal(2, multi.StreamAsync<int>().SingleAsync().Result);
+                Assert.Equal(3, multi.ReadFirstOrDefaultAsync<int>().Result);
+                Assert.Equal(4, multi.StreamAsync<int>().SingleAsync().Result);
+                Assert.Equal(5, multi.ReadFirstOrDefaultAsync<int>().Result);
+            }
+        }
+
+        [Fact]
+        public async Task TestMultiClosedConnAsync()
+        {
+            using (var conn = GetClosedConnection())
+            {
+                using (SqlMapper.GridReader multi = await conn.QueryMultipleAsync("select 1; select 2").ConfigureAwait(false))
+                {
+                    Assert.Equal(1, multi.StreamAsync<int>().SingleAsync().Result);
+                    Assert.Equal(2, multi.StreamAsync<int>().SingleAsync().Result);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task TestMultiClosedConnAsyncViaFirstOrDefault()
+        {
+            using (var conn = GetClosedConnection())
+            {
+                using (SqlMapper.GridReader multi = await conn.QueryMultipleAsync("select 1; select 2; select 3; select 4; select 5").ConfigureAwait(false))
+                {
+                    Assert.Equal(1, multi.ReadFirstOrDefaultAsync<int>().Result);
+                    Assert.Equal(2, multi.StreamAsync<int>().SingleAsync().Result);
+                    Assert.Equal(3, multi.ReadFirstOrDefaultAsync<int>().Result);
+                    Assert.Equal(4, multi.StreamAsync<int>().SingleAsync().Result);
+                    Assert.Equal(5, multi.ReadFirstOrDefaultAsync<int>().Result);
+                }
+            }
+        }
+
+        private static async Task LiteralReplacement(IDbConnection conn)
+        {
+            try
+            {
+                await conn.ExecuteAsync("drop table literal1").ConfigureAwait(false);
+            }
+            catch { /* don't care */ }
+            await conn.ExecuteAsync("create table literal1 (id int not null, foo int not null)").ConfigureAwait(false);
+            await conn.ExecuteAsync("insert literal1 (id,foo) values ({=id}, @foo)", new { id = 123, foo = 456 }).ConfigureAwait(false);
+            var rows = new[] { new { id = 1, foo = 2 }, new { id = 3, foo = 4 } };
+            await conn.ExecuteAsync("insert literal1 (id,foo) values ({=id}, @foo)", rows).ConfigureAwait(false);
+            var count = await conn.StreamAsync<int>("select count(1) from literal1 where id={=foo}", new { foo = 123 }).SingleAsync().ConfigureAwait(false);
+            Assert.Equal(1, count);
+            int sum = await conn.StreamAsync<int>("select sum(id) + sum(foo) from literal1").SingleAsync().ConfigureAwait(false);
+            Assert.Equal(sum, 123 + 456 + 1 + 2 + 3 + 4);
+        }
+
+        private static async Task LiteralReplacementDynamic(IDbConnection conn)
+        {
+            var args = new DynamicParameters();
+            args.Add("id", 123);
+            try { await conn.ExecuteAsync("drop table literal2").ConfigureAwait(false); }
+            catch { /* don't care */ }
+            await conn.ExecuteAsync("create table literal2 (id int not null)").ConfigureAwait(false);
+            await conn.ExecuteAsync("insert literal2 (id) values ({=id})", args).ConfigureAwait(false);
+
+            args = new DynamicParameters();
+            args.Add("foo", 123);
+            var count = await conn.StreamAsync<int>("select count(1) from literal2 where id={=foo}", args).SingleAsync().ConfigureAwait(false);
+            Assert.Equal(1, count);
+        }
+
+        [Fact]
+        public async Task LiteralInAsync()
+        {
+            await connection.ExecuteAsync("create table #literalin(id int not null);").ConfigureAwait(false);
+            await connection.ExecuteAsync("insert #literalin (id) values (@id)", new[] {
+                new { id = 1 },
+                new { id = 2 },
+                new { id = 3 },
+            }).ConfigureAwait(false);
+            var count = await connection.StreamAsync<int>("select count(1) from #literalin where id in {=ids}",
+                new { ids = new[] { 1, 3, 4 } }).SingleAsync().ConfigureAwait(false);
+            Assert.Equal(2, count);
+        }
+
+        private class BasicType
+        {
+            public string Value { get; set; }
+        }
+
+        [Fact]
+        public async Task TypeBasedViaTypeAsync()
+        {
+            Type type = Common.GetSomeType();
+
+            dynamic actual = await MarsConnection.StreamAsync(type, "select @A as [A], @B as [B]", new { A = 123, B = "abc" }).FirstOrDefaultAsync().ConfigureAwait(false);
+            Assert.Equal(((object)actual).GetType(), type);
+            int a = actual.A;
+            string b = actual.B;
+            Assert.Equal(123, a);
+            Assert.Equal("abc", b);
+        }
+
+        [Fact]
+        public async Task Issue346_StreamAsyncConvert()
+        {
+            int i = await connection.StreamAsync<int>("Select Cast(123 as bigint)").FirstAsync().ConfigureAwait(false);
+            Assert.Equal(123, i);
+        }
+
+        [Fact]
+        public async Task TestSupportForDynamicParametersOutputExpressions_Query_Default()
+        {
+            var bob = new Person { Name = "bob", PersonId = 1, Address = new Address { PersonId = 2 } };
+
+            var p = new DynamicParameters(bob);
+            p.Output(bob, b => b.PersonId);
+            p.Output(bob, b => b.Occupation);
+            p.Output(bob, b => b.NumberOfLegs);
+            p.Output(bob, b => b.Address.Name);
+            p.Output(bob, b => b.Address.PersonId);
+
+            var result = await connection.StreamAsync<int>(@"
+SET @Occupation = 'grillmaster' 
+SET @PersonId = @PersonId + 1 
+SET @NumberOfLegs = @NumberOfLegs - 1
+SET @AddressName = 'bobs burgers'
+SET @AddressPersonId = @PersonId
+select 42", p).SingleAsync().ConfigureAwait(false);
+
+            Assert.Equal("grillmaster", bob.Occupation);
+            Assert.Equal(2, bob.PersonId);
+            Assert.Equal(1, bob.NumberOfLegs);
+            Assert.Equal("bobs burgers", bob.Address.Name);
+            Assert.Equal(2, bob.Address.PersonId);
+            Assert.Equal(42, result);
+        }
+
+        [Fact]
+        public async Task TestSupportForDynamicParametersOutputExpressions_Query_BufferedAsync()
+        {
+            var bob = new Person { Name = "bob", PersonId = 1, Address = new Address { PersonId = 2 } };
+
+            var p = new DynamicParameters(bob);
+            p.Output(bob, b => b.PersonId);
+            p.Output(bob, b => b.Occupation);
+            p.Output(bob, b => b.NumberOfLegs);
+            p.Output(bob, b => b.Address.Name);
+            p.Output(bob, b => b.Address.PersonId);
+
+            var result = await connection.StreamAsync<int>(new CommandDefinition(@"
+SET @Occupation = 'grillmaster' 
+SET @PersonId = @PersonId + 1 
+SET @NumberOfLegs = @NumberOfLegs - 1
+SET @AddressName = 'bobs burgers'
+SET @AddressPersonId = @PersonId
+select 42", p, flags: CommandFlags.Buffered)).SingleAsync().ConfigureAwait(false);
+
+            Assert.Equal("grillmaster", bob.Occupation);
+            Assert.Equal(2, bob.PersonId);
+            Assert.Equal(1, bob.NumberOfLegs);
+            Assert.Equal("bobs burgers", bob.Address.Name);
+            Assert.Equal(2, bob.Address.PersonId);
+            Assert.Equal(42, result);
+        }
+
+        [Fact]
+        public async Task TestSupportForDynamicParametersOutputExpressions_Query_NonBufferedAsync()
+        {
+            var bob = new Person { Name = "bob", PersonId = 1, Address = new Address { PersonId = 2 } };
+
+            var p = new DynamicParameters(bob);
+            p.Output(bob, b => b.PersonId);
+            p.Output(bob, b => b.Occupation);
+            p.Output(bob, b => b.NumberOfLegs);
+            p.Output(bob, b => b.Address.Name);
+            p.Output(bob, b => b.Address.PersonId);
+
+            var result = await connection.StreamAsync<int>(new CommandDefinition(@"
+SET @Occupation = 'grillmaster' 
+SET @PersonId = @PersonId + 1 
+SET @NumberOfLegs = @NumberOfLegs - 1
+SET @AddressName = 'bobs burgers'
+SET @AddressPersonId = @PersonId
+select 42", p, flags: CommandFlags.None)).SingleAsync().ConfigureAwait(false);
+
+            Assert.Equal("grillmaster", bob.Occupation);
+            Assert.Equal(2, bob.PersonId);
+            Assert.Equal(1, bob.NumberOfLegs);
+            Assert.Equal("bobs burgers", bob.Address.Name);
+            Assert.Equal(2, bob.Address.PersonId);
+            Assert.Equal(42, result);
+        }
+
+        [Fact]
+        public async Task TestSupportForDynamicParametersOutputExpressions_QueryMultipleAsync()
+        {
+            var bob = new Person { Name = "bob", PersonId = 1, Address = new Address { PersonId = 2 } };
+
+            var p = new DynamicParameters(bob);
+            p.Output(bob, b => b.PersonId);
+            p.Output(bob, b => b.Occupation);
+            p.Output(bob, b => b.NumberOfLegs);
+            p.Output(bob, b => b.Address.Name);
+            p.Output(bob, b => b.Address.PersonId);
+
+            int x, y;
+            using (var multi = await connection.QueryMultipleAsync(@"
+SET @Occupation = 'grillmaster' 
+SET @PersonId = @PersonId + 1 
+SET @NumberOfLegs = @NumberOfLegs - 1
+SET @AddressName = 'bobs burgers'
+select 42
+select 17
+SET @AddressPersonId = @PersonId", p).ConfigureAwait(false))
+            {
+                x = multi.StreamAsync<int>().SingleAsync().Result;
+                y = multi.StreamAsync<int>().SingleAsync().Result;
+            }
+
+            Assert.Equal("grillmaster", bob.Occupation);
+            Assert.Equal(2, bob.PersonId);
+            Assert.Equal(1, bob.NumberOfLegs);
+            Assert.Equal("bobs burgers", bob.Address.Name);
+            Assert.Equal(2, bob.Address.PersonId);
+            Assert.Equal(42, x);
+            Assert.Equal(17, y);
+        }
+
+        [Fact]
+        public async Task TestSubsequentQueriesSuccessAsync()
+        {
+            var data0 = await connection.StreamAsync<AsyncFoo0>("select 1 as [Id] where 1 = 0").ToListAsync().ConfigureAwait(false);
+            Assert.Empty(data0);
+
+            var data1 = await connection.StreamAsync<AsyncFoo1>(new CommandDefinition("select 1 as [Id] where 1 = 0", flags: CommandFlags.Buffered)).ToListAsync().ConfigureAwait(false);
+            Assert.Empty(data1);
+
+            var data2 = await connection.StreamAsync<AsyncFoo2>(new CommandDefinition("select 1 as [Id] where 1 = 0", flags: CommandFlags.None)).ToListAsync().ConfigureAwait(false);
+            Assert.Empty(data2);
+
+            data0 = await connection.StreamAsync<AsyncFoo0>("select 1 as [Id] where 1 = 0").ToListAsync().ConfigureAwait(false);
+            Assert.Empty(data0);
+
+            data1 = await connection.StreamAsync<AsyncFoo1>(new CommandDefinition("select 1 as [Id] where 1 = 0", flags: CommandFlags.Buffered)).ToListAsync().ConfigureAwait(false);
+            Assert.Empty(data1);
+
+            data2 = await connection.StreamAsync<AsyncFoo2>(new CommandDefinition("select 1 as [Id] where 1 = 0", flags: CommandFlags.None)).ToListAsync().ConfigureAwait(false);
+            Assert.Empty(data2);
+        }
+
+        private class AsyncFoo0 { public int Id { get; set; } }
+
+        private class AsyncFoo1 { public int Id { get; set; } }
+
+        private class AsyncFoo2 { public int Id { get; set; } }
+
+        [Fact]
+        public async Task TestMultiMapArbitraryMapsAsync()
+        {
+            // please excuse the trite example, but it is easier to follow than a more real-world one
+            const string createSql = @"
+                create table #ReviewBoards (Id int, Name varchar(20), User1Id int, User2Id int, User3Id int, User4Id int, User5Id int, User6Id int, User7Id int, User8Id int, User9Id int)
+                create table #Users (Id int, Name varchar(20))
+
+                insert #Users values(1, 'User 1')
+                insert #Users values(2, 'User 2')
+                insert #Users values(3, 'User 3')
+                insert #Users values(4, 'User 4')
+                insert #Users values(5, 'User 5')
+                insert #Users values(6, 'User 6')
+                insert #Users values(7, 'User 7')
+                insert #Users values(8, 'User 8')
+                insert #Users values(9, 'User 9')
+
+                insert #ReviewBoards values(1, 'Review Board 1', 1, 2, 3, 4, 5, 6, 7, 8, 9)
+";
+            await connection.ExecuteAsync(createSql).ConfigureAwait(false);
+            try
+            {
+                const string sql = @"
+                select 
+                    rb.Id, rb.Name,
+                    u1.*, u2.*, u3.*, u4.*, u5.*, u6.*, u7.*, u8.*, u9.*
+                from #ReviewBoards rb
+                    inner join #Users u1 on u1.Id = rb.User1Id
+                    inner join #Users u2 on u2.Id = rb.User2Id
+                    inner join #Users u3 on u3.Id = rb.User3Id
+                    inner join #Users u4 on u4.Id = rb.User4Id
+                    inner join #Users u5 on u5.Id = rb.User5Id
+                    inner join #Users u6 on u6.Id = rb.User6Id
+                    inner join #Users u7 on u7.Id = rb.User7Id
+                    inner join #Users u8 on u8.Id = rb.User8Id
+                    inner join #Users u9 on u9.Id = rb.User9Id
+";
+
+                var types = new[] { typeof(ReviewBoard), typeof(User), typeof(User), typeof(User), typeof(User), typeof(User), typeof(User), typeof(User), typeof(User), typeof(User) };
+
+                Func<object[], ReviewBoard> mapper = (objects) =>
+                {
+                    var board = (ReviewBoard)objects[0];
+                    board.User1 = (User)objects[1];
+                    board.User2 = (User)objects[2];
+                    board.User3 = (User)objects[3];
+                    board.User4 = (User)objects[4];
+                    board.User5 = (User)objects[5];
+                    board.User6 = (User)objects[6];
+                    board.User7 = (User)objects[7];
+                    board.User8 = (User)objects[8];
+                    board.User9 = (User)objects[9];
+                    return board;
+                };
+
+                var data = await connection.StreamAsync<ReviewBoard>(sql, types, mapper).ToListAsync().ConfigureAwait(false);
+
+                var p = data[0];
+                Assert.Equal(1, p.Id);
+                Assert.Equal("Review Board 1", p.Name);
+                Assert.Equal(1, p.User1.Id);
+                Assert.Equal(2, p.User2.Id);
+                Assert.Equal(3, p.User3.Id);
+                Assert.Equal(4, p.User4.Id);
+                Assert.Equal(5, p.User5.Id);
+                Assert.Equal(6, p.User6.Id);
+                Assert.Equal(7, p.User7.Id);
+                Assert.Equal(8, p.User8.Id);
+                Assert.Equal(9, p.User9.Id);
+                Assert.Equal("User 1", p.User1.Name);
+                Assert.Equal("User 2", p.User2.Name);
+                Assert.Equal("User 3", p.User3.Name);
+                Assert.Equal("User 4", p.User4.Name);
+                Assert.Equal("User 5", p.User5.Name);
+                Assert.Equal("User 6", p.User6.Name);
+                Assert.Equal("User 7", p.User7.Name);
+                Assert.Equal("User 8", p.User8.Name);
+                Assert.Equal("User 9", p.User9.Name);
+            }
+            finally
+            {
+                connection.Execute("drop table #Users drop table #ReviewBoards");
+            }
+        }
+
+        [Fact]
+        public async Task Issue157_ClosedReaderAsync()
+        {
+            var args = new { x = 42 };
+            const string sql = "select 123 as [A], 'abc' as [B] where @x=42";
+            var row = await connection.StreamAsync<SomeType>(new CommandDefinition(
+                sql, args, flags: CommandFlags.None)).SingleAsync().ConfigureAwait(false);
+            Assert.NotNull(row);
+            Assert.Equal(123, row.A);
+            Assert.Equal("abc", row.B);
+
+            args = new { x = 5 };
+            Assert.False(await connection.StreamAsync<SomeType>(new CommandDefinition(sql, args, flags: CommandFlags.None)).AnyAsync().ConfigureAwait(false));
+        }
+
+        [Fact]
+        public async Task TestAtEscaping()
+        {
+            var id = await connection.StreamAsync<int>(@"
+                declare @@Name int
+                select @@Name = @Id+1
+                select @@Name
+                ", new Product { Id = 1 }).SingleAsync().ConfigureAwait(false);
+            Assert.Equal(2, id);
+        }
+
+        [Fact]
+        public async Task Issue563_StreamAsyncShouldThrowException()
+        {
+            try
+            {
+                var data = await connection.StreamAsync<int>("select 1 union all select 2; RAISERROR('after select', 16, 1);").ToListAsync().ConfigureAwait(false);
+                Assert.True(false, "Expected Exception");
+            }
+            catch (Exception ex) when (ex.GetType().Name == "SqlException" && ex.Message == "after select") { /* swallow only this */ }
+        }
+    }
+}
+#endif // NET5_0 || NETCOREAPP3_1

--- a/tests/Dapper.Tests/Dapper.Tests.csproj
+++ b/tests/Dapper.Tests/Dapper.Tests.csproj
@@ -29,6 +29,9 @@
     <ProjectReference Include="../../Dapper.EntityFramework/Dapper.EntityFramework.csproj" />
     <Reference Include="System.Data.Linq" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'net5.0'">
+    <PackageReference Include="System.Linq.Async" Version="5.0.0" />
+  </ItemGroup>
   <ItemGroup>
     <!-- Conditionals make the tooling go crazy...just include them for this test project -->
     <Content Include="$(NuGetPackageRoot)\microsoft.sqlserver.types\14.0.1016.290\nativeBinaries\**\*.dll" CopyToOutputDirectory="PreserveNewest" />

--- a/tests/Dapper.Tests/MiscTests.cs
+++ b/tests/Dapper.Tests/MiscTests.cs
@@ -222,6 +222,13 @@ namespace Dapper.Tests
             Assert.Null(Assert.Single(list));
             list = await connection.QueryAsync<int?>(sql);
             Assert.Null(Assert.Single(list));
+            list = await connection.QueryAsync<int?>(sql);
+            Assert.Null(Assert.Single(list));
+
+#if NETCOREAPP3_1 || NET5_0
+            list = await connection.StreamAsync<int?>(sql).ToListAsync();
+            Assert.Null(Assert.Single(list));
+#endif
 
             // Single row paths
             Assert.Null(connection.QueryFirst<int?>(sql));
@@ -257,6 +264,10 @@ namespace Dapper.Tests
                 Assert.Equal(exception, ex.Message);
                 ex = await Assert.ThrowsAsync<DataException>(() => connection.QuerySingleOrDefaultAsync<T>(sql));
                 Assert.Equal(exception, ex.Message);
+#if NETCOREAPP3_1 || NET5_0
+                ex = await Assert.ThrowsAsync<DataException>(async () => await connection.StreamAsync<T>(sql).ToListAsync());
+                Assert.Equal(exception, ex.Message);
+#endif
             }
 
             // Null value throws

--- a/tests/Dapper.Tests/MiscTests.cs
+++ b/tests/Dapper.Tests/MiscTests.cs
@@ -222,8 +222,6 @@ namespace Dapper.Tests
             Assert.Null(Assert.Single(list));
             list = await connection.QueryAsync<int?>(sql);
             Assert.Null(Assert.Single(list));
-            list = await connection.QueryAsync<int?>(sql);
-            Assert.Null(Assert.Single(list));
 
 #if NETCOREAPP3_1 || NET5_0
             list = await connection.StreamAsync<int?>(sql).ToListAsync();


### PR DESCRIPTION
Add `StreamAsync` alternatives to `connecton.QueryAsync` and `gridReader.ReadAsync` to support `IAsyncEnumerable` in a non-breaking way.

Unlike `QueryAsync`, stream will default to unbuffered.