### PR TITLE
Fix NETSDK1174

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -129,7 +129,7 @@ A key feature of Dapper is performance. The following metrics show how long it t
 
 The benchmarks can be found in [Dapper.Tests.Performance](https://github.com/DapperLib/Dapper/tree/main/benchmarks/Dapper.Tests.Performance) (contributions welcome!) and can be run via:
 ```bash
-dotnet run -p .\benchmarks\Dapper.Tests.Performance\ -c Release -f netcoreapp3.1 -- -f * --join
+dotnet run --project .\benchmarks\Dapper.Tests.Performance\ -c Release -f netcoreapp3.1 -- -f * --join
 ```
 Output from the latest run is:
 ``` ini


### PR DESCRIPTION
As per https://docs.microsoft.com/en-us/dotnet/core/tools/sdk-errors/netsdk1174 `-p` is deprecated in favor of `--project`
This PR fixes the deprecation warning when running the benchmarks as currently described in the README.