### PR TITLE
EF Core benchmarks for connections w/ passwords

### DIFF
--- a/benchmarks/Dapper.Tests.Performance/Benchmarks.EntityFrameworkCore.cs
+++ b/benchmarks/Dapper.Tests.Performance/Benchmarks.EntityFrameworkCore.cs
@@ -19,7 +19,7 @@ namespace Dapper.Tests.Performance
         public void Setup()
         {
             BaseSetup();
-            Context = new EFCoreContext(_connection.ConnectionString);
+            Context = new EFCoreContext(ConnectionString);
         }
 
         [Benchmark(Description = "First")]


### PR DESCRIPTION
`SqlConnection.ConnectionString` returns the original connection string _without_ the password.
Use `BenchmarkBase.ConnectionString` to ensure successful connections.