### PR TITLE
Enhance literal tokens capabilities

### DIFF
--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -2279,7 +2279,7 @@ namespace Dapper
 
         // look for ? / @ / : *by itself*
         private static readonly Regex smellsLikeOleDb = new Regex(@"(?<![\p{L}\p{N}@_])[?@:](?![\p{L}\p{N}@_])", RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant | RegexOptions.Compiled),
-            literalTokens = new Regex(@"(?<![\p{L}\p{N}_])\{=([\p{L}\p{N}_]+)\}", RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant | RegexOptions.Compiled),
+            literalTokens = new Regex(@"\{=([\p{L}\p{N}_]+)\}", RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant | RegexOptions.Compiled),
             pseudoPositional = new Regex(@"\?([\p{L}_][\p{L}\p{N}_]*)\?", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
 
         /// <summary>

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,7 @@ Note: to get the latest pre-release build, add ` -Pre` to the end of the command
 ### unreleased
 
 (note: new PRs will not be merged until they add release note wording here)
+- Enhance `Literal Tokens` capabilities, now we can use `Literal Tokens` as a suffix of table for `Table Sharding`.
 
 ### 2.0.123
 

--- a/tests/Dapper.Tests/TestBase.cs
+++ b/tests/Dapper.Tests/TestBase.cs
@@ -97,6 +97,11 @@ namespace Dapper.Tests
 
         static TestBase()
         {
+            var defaultCultureInfo = CultureInfo.GetCultureInfo("en-US");
+            CultureInfo.DefaultThreadCurrentCulture = defaultCultureInfo;
+            CultureInfo.DefaultThreadCurrentUICulture = defaultCultureInfo;
+            Thread.CurrentThread.CurrentCulture = defaultCultureInfo;
+            Thread.CurrentThread.CurrentUICulture = defaultCultureInfo;
             Console.WriteLine("Dapper: " + typeof(SqlMapper).AssemblyQualifiedName);
             var provider = DatabaseProvider<TProvider>.Instance;
             Console.WriteLine("Using Connectionstring: {0}", provider.GetConnectionString());
@@ -114,6 +119,13 @@ namespace Dapper.Tests
                 Console.WriteLine("failed.");
                 Console.Error.WriteLine(ex.Message);
             }
+        }
+
+        public TestBase()
+        {
+            var defaultCultureInfo = CultureInfo.GetCultureInfo("en-US");
+            Thread.CurrentThread.CurrentCulture = defaultCultureInfo;
+            Thread.CurrentThread.CurrentUICulture = defaultCultureInfo;
         }
 
         public virtual void Dispose()


### PR DESCRIPTION
Enhance `Literal Tokens` capabilities, now we can use `Literal Tokens` as a suffix of table for `Table Sharding`.
before:
```csharp
connection.Query("select * from User_34 where Id= {=Id}", new { TableId = 5201314%64 , Id = 5201314 });
```
after:
```csharp
connection.Query("select * from User_{=TableId} where Id= {=Id}", new { TableId = 5201314%64 , Id = 5201314 });
```