### PR TITLE
Issue #1754 resolution - Allow INullTypeHandler to allow parsing of nulls on  custom type handlers

### DIFF
--- a/Dapper/SqlMapper.ITypeHandler.cs
+++ b/Dapper/SqlMapper.ITypeHandler.cs
@@ -25,5 +25,18 @@ namespace Dapper
             /// <returns>The typed value</returns>
             object Parse(Type destinationType, object value);
         }
+
+        /// <summary>
+        /// Implement this interface along side ITypeHandler if you want nulls to be passed to your custom value parsing
+        /// </summary>
+        public interface INullTypeHandler
+        {
+            /// <summary>
+            /// Parse a database back to a typed value (or null if not required)
+            /// </summary>
+            /// <param name="destinationType">The type to parse to</param>
+            /// <returns>The typed value</returns>
+            object ParseNull(Type destinationType);
+        }
     }
 }

--- a/Dapper/SqlMapper.TypeHandlerCache.cs
+++ b/Dapper/SqlMapper.TypeHandlerCache.cs
@@ -25,6 +25,19 @@ namespace Dapper
             /// <summary>
             /// Not intended for direct usage.
             /// </summary>
+            [Obsolete(ObsoleteInternalUsageOnly, true)]
+            public static bool HasNullHandler() => handler is SqlMapper.INullTypeHandler;
+
+            /// <summary>
+            /// Not intended for direct usage.
+            /// </summary>
+            [Obsolete(ObsoleteInternalUsageOnly, true)]
+            public static T ParseNull() => (T)((SqlMapper.INullTypeHandler)handler).ParseNull(typeof(T));
+
+
+            /// <summary>
+            /// Not intended for direct usage.
+            /// </summary>
             /// <param name="parameter">The parameter to set a value for.</param>
             /// <param name="value">The value to set.</param>
             [Obsolete(ObsoleteInternalUsageOnly, true)]


### PR DESCRIPTION
This change allows a developer to implement an additional interface (INullTypeHandler) on a custom type handler if they want to be able to handle the parsing of nulls (as opposed to the default behaviour of ignore nulls).

This has been implemented as an interface rather than extending the behaviour of SqlMapper.Settings.ApplyNullValues. This is to make it fully backwards compatible for existing code and ensure it doesn't impact performance.

There is an example of existing behaviour: [Existing behaviour example](https://dotnetfiddle.net/ph3TQK)

Example of how to implement desired behaviour is in the supplied unit tests.

Apologies - I can't see where to update documentation, if someone could point me in the right direction I will happily contribute to the documentation too.

Changes:

- Unit tests to show desired behaviour and ensure backwards compatible behaviour
- Create INullTypeHandler interface
- Change LoadReaderValueOrBranchToDBNullLabel to check for implementation of INullTypeHandler
- Alter GenerateDeserializerFromMap to produce IL which will use the null handler if required

Performance assessment:

- Performance overhead = 1 check for INullTypeHandler per mapped ITypeHandler type on generation of IL.
- No performance overhead at runtime of IL (because the generated IL is the same if the interface isn't implemented)
- If Interface is implemented the same pattern as ITypeHandlerParse is used

Impact assessment:

- Developer is required to implement a new interface. No change to any existing behaviours. Unit test supplied to uphold this.