### PR TITLE
Add option to persist enum names

### DIFF
--- a/Dapper/SqlMapper.Settings.cs
+++ b/Dapper/SqlMapper.Settings.cs
@@ -99,6 +99,11 @@ namespace Dapper
             /// instead of the original name; for most scenarios, this is ignored since the name is redundant, but "snowflake" requires this.
             /// </summary>
             public static bool UseIncrementalPseudoPositionalParameterNames { get; set; }
+
+            /// <summary>
+            /// Whether to persist an enum by its name (<see cref="Enum.ToString()"/>) instead of by its underlying numeric value.
+            /// </summary>
+            public static bool PersistEnumsByName { get; set; }
         }
     }
 }


### PR DESCRIPTION
When the new `PersistEnumsByName` setting is true, an enum is persisted by its name (`Enum.ToString()`) instead of by its numeric value.

This is sort of an alternative solution to issue #259, but it doesn't directly address that issue by changing how custom type handlers are used. Instead, it adds a new setting, `PersistEnumsByName`, which I believe addresses what most users actually want - to be able to persist an enums by their name. When this setting is false (its default value), the current behavior is completely unchanged. Admittedly, there is no granularity with how enums are handled; you couldn't have some enums persisted by name and others by their underlying value. Supporting that scenario would add significant complexity, and I don't think there is enough demand to justify it.

Fixes #813.