### PR TITLE
Adds MatchConstructorParametersWithUnderscores

### DIFF
--- a/tests/Dapper.Tests/MiscTests.cs
+++ b/tests/Dapper.Tests/MiscTests.cs
@@ -1273,5 +1273,27 @@ insert TPTable (Value) values (2), (568)");
             public int Id { get; }
             public string Name { get; } = "abc";
         }
+
+        [Fact]
+        public void TestConstructorParametersWithUnderscoredColumns()
+        {
+            DefaultTypeMap.MatchConstructorParametersWithUnderscores = true;
+            DefaultTypeMap.MatchFieldsAndPropertiesWithUnderscores = true;
+            var obj = connection.QuerySingle<HazGetOnlyAndCtor>("select 42 as [id_property], 'def' as [name_property];");
+            Assert.Equal(42, obj.IdProperty);
+            Assert.Equal("def", obj.NameProperty);
+        }
+
+        private class HazGetOnlyAndCtor
+        {
+            public int IdProperty { get; }
+            public string NameProperty { get; }
+
+            public HazGetOnlyAndCtor(int idProperty, string nameProperty)
+            {
+                IdProperty = idProperty;
+                NameProperty = nameProperty;
+            }
+        }
     }
 }


### PR DESCRIPTION
Resolves #818.

Adds the static `MatchConstructorParametersWithUnderscores` property for `DefaultTypeMap` which allows matching columns containing underscores to constructor parameters (eg. `user_id` matches `userId`).

This commit also renames `MatchNamesWithUnderscores` to `MatchFieldsAndPropertiesWithUnderscores` for clarity. `MatchNamesWithUnderscores` is marked as obsolete and simply maps to `MatchFieldsAndPropertiesWithUnderscores`.