### PR TITLE
Fix issue #1164 - arithmetic overflow for unsigned integer mapping 

### DIFF
--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -3788,20 +3788,20 @@ namespace Dapper
                         switch (Type.GetTypeCode(via ?? to))
                         {
                             case TypeCode.Byte:
-                                opCode = OpCodes.Conv_Ovf_I1_Un; break;
+                                opCode = OpCodes.Conv_Ovf_U1_Un; break;
                             case TypeCode.SByte:
                                 opCode = OpCodes.Conv_Ovf_I1; break;
                             case TypeCode.UInt16:
-                                opCode = OpCodes.Conv_Ovf_I2_Un; break;
+                                opCode = OpCodes.Conv_Ovf_U2_Un; break;
                             case TypeCode.Int16:
                                 opCode = OpCodes.Conv_Ovf_I2; break;
                             case TypeCode.UInt32:
-                                opCode = OpCodes.Conv_Ovf_I4_Un; break;
+                                opCode = OpCodes.Conv_Ovf_U4_Un; break;
                             case TypeCode.Boolean: // boolean is basically an int, at least at this level
                             case TypeCode.Int32:
                                 opCode = OpCodes.Conv_Ovf_I4; break;
                             case TypeCode.UInt64:
-                                opCode = OpCodes.Conv_Ovf_I8_Un; break;
+                                opCode = OpCodes.Conv_Ovf_U8_Un; break;
                             case TypeCode.Int64:
                                 opCode = OpCodes.Conv_Ovf_I8; break;
                             case TypeCode.Single:

--- a/tests/Dapper.Tests/MiscTests.cs
+++ b/tests/Dapper.Tests/MiscTests.cs
@@ -1287,5 +1287,42 @@ insert TPTable (Value) values (2), (568)");
                 NameProperty = nameProperty;
             }
         }
+
+        [Fact]
+        public void Issue1164_OverflowExceptionForByte()
+        {
+            const string sql = "select cast(200 as smallint) as [value]"; // 200 more than sbyte.MaxValue but less than byte.MaxValue 
+            Issue1164Object<byte> obj = connection.QuerySingle<Issue1164Object<byte>>(sql);
+            Assert.StrictEqual(200, obj.Value);
+        }
+
+        [Fact]
+        public void Issue1164_OverflowExceptionForUInt16()
+        {
+            const string sql = "select cast(40000 as bigint) as [value]"; // 40000 more than short.MaxValue but less than ushort.MaxValue 
+            Issue1164Object<ushort> obj = connection.QuerySingle<Issue1164Object<ushort>>(sql);
+            Assert.StrictEqual(40000, obj.Value);
+        }
+
+        [Fact]
+        public void Issue1164_OverflowExceptionForUInt32()
+        {
+            const string sql = "select cast(4000000000 as bigint) as [value]"; // 4000000000 more than int.MaxValue but less than uint.MaxValue 
+            Issue1164Object<uint> obj = connection.QuerySingle<Issue1164Object<uint>>(sql);
+            Assert.StrictEqual(4000000000, obj.Value);
+        }
+
+        [Fact]
+        public void Issue1164_OverflowExceptionForUInt64()
+        {
+            const string sql = "select cast(10000000000000000000.0 as float) as [value]"; // 10000000000000000000 more than long.MaxValue but less than ulong.MaxValue 
+            Issue1164Object<ulong> obj = connection.QuerySingle<Issue1164Object<ulong>>(sql);
+            Assert.StrictEqual(10000000000000000000, obj.Value);
+        }
+
+        private class Issue1164Object<T>
+        {
+            public T Value;
+        }
     }
 }


### PR DESCRIPTION
Fix arithmetic overflow for unsigned integer mapping (byte, ushort, uint, ulong)
Add tests to reproduce issue #1164