### PR TITLE
Support for Type mapping.

### DIFF
--- a/Dapper/SqlMapper.TypeDeserializerCache.cs
+++ b/Dapper/SqlMapper.TypeDeserializerCache.cs
@@ -43,7 +43,15 @@ namespace Dapper
                         found = (TypeDeserializerCache)byType[type];
                         if (found == null)
                         {
-                            byType[type] = found = new TypeDeserializerCache(type);
+                            var mapped = SqlMapper.abstractTypeMap?.Invoke(type);
+                            if( mapped != null && mapped != type )
+                            {
+                                byType[type] = byType[mapped] = found = new TypeDeserializerCache(mapped);
+                            }
+                            else
+                            {
+                                byType[type] = found = new TypeDeserializerCache(type);
+                            }
                         }
                     }
                 }

--- a/tests/Dapper.Tests/AbstractTypeMappingTests.cs
+++ b/tests/Dapper.Tests/AbstractTypeMappingTests.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Data;
+using System.Linq;
+using Xunit;
+
+namespace Dapper.Tests
+{
+    [Collection(NonParallelDefinition.Name)]
+    public sealed class SystemSqlClientAbstractTypeMappingTests : AbstractTypeMappingTests<SystemSqlClientProvider> { }
+#if MSSQLCLIENT
+    [Collection(NonParallelDefinition.Name)]
+    public sealed class MicrosoftSqlClientAbstractTypeMappingTests : AbstractTypeMappingTests<MicrosoftSqlClientProvider> { }
+#endif
+
+    public abstract class AbstractTypeMappingTests<TProvider> : TestBase<TProvider> where TProvider : DatabaseProvider
+    {
+        [Fact]
+        public void TestAbstractTypeMapping()
+        {
+            var previousMapping = SqlMapper.CurrentAbstractTypeMap;
+            SqlMapper.PurgeQueryCache();
+            try
+            {
+                SqlMapper.SetAbstractTypeMap(t => t == typeof(AbstractTypeMapping.IThing) ? typeof(AbstractTypeMapping.Thing) : null);
+                
+                var thing = connection.Query<AbstractTypeMapping.IThing>("select 'Hello!' Name, 42 Power").First();
+                Assert.Equal(42, thing.Power);
+                Assert.Equal("Hello!", thing.Name);
+            }
+            finally
+            {
+                SqlMapper.SetAbstractTypeMap( previousMapping );
+                SqlMapper.PurgeQueryCache();
+           }
+        }
+
+        [Fact]
+        public void TestAbstractTypeMappingCombination()
+        {
+            var previousMapping = SqlMapper.CurrentAbstractTypeMap;
+            SqlMapper.PurgeQueryCache();
+            try
+            {
+                // IThing is mapped to Thing.
+                SqlMapper.SetAbstractTypeMap(t => t == typeof(AbstractTypeMapping.IThing) ? typeof(AbstractTypeMapping.Thing) : null);
+
+                // "Override": IThing is mapped to ThingMultiplier.
+                SqlMapper.AddAbstractTypeMap(current =>
+                {
+                    return t =>
+                    {
+                        if (t == typeof(AbstractTypeMapping.IThing)) return typeof(AbstractTypeMapping.ThingMultiplier);
+                        return current?.Invoke(t);
+                    };
+                });
+
+                var thing = connection.Query<AbstractTypeMapping.IThing>("select 'Hello!' Name, 42 Power").First();
+                Assert.Equal(84, thing.Power);
+                Assert.Equal("Hello!", thing.Name);
+            }
+            finally
+            {
+                SqlMapper.SetAbstractTypeMap( previousMapping );
+                SqlMapper.PurgeQueryCache();
+            }
+        }
+
+        public static class AbstractTypeMapping
+        {
+            public interface IThing
+            {
+                int Power { get; }
+
+                string Name { get; }
+            }
+
+            public class Thing : IThing
+            {
+                public int Power { get; set; }
+
+                public string Name { get; set; }
+            }
+
+            public class ThingMultiplier : IThing
+            {
+                int _power;
+
+                public int Power { get => _power * 2; set => _power = value; }
+
+                public string Name { get; set; }
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
This adds support for Type mapping, typically resolving the issue #1104 by allowing a requested type to be mapped to another type. The core of this PR is rather light since everything is done in the TypeDeserializerCache:

When a type is new to the cache, instead of considering only the requested type, a mapping function is called and if it provides a type, both the requested and mapped types are cached. 

Currently, no check is done (with `IsAssignableFrom`) to enforce the relationship between the requested and mapped types
but this can easily be done. Not sure it's useful though...

