### PR TITLE
When there are too many parameters, parameterized insertion has performance problems.

### DIFF
--- a/Dapper/DynamicParameters.cs
+++ b/Dapper/DynamicParameters.cs
@@ -170,8 +170,6 @@ namespace Dapper
         {
             var literals = SqlMapper.GetLiteralTokens(identity.sql);
 
-            HashSet<string> cleanNames = new HashSet<string>();
-
             if (templates != null)
             {
                 foreach (var template in templates)
@@ -224,12 +222,6 @@ namespace Dapper
                 }
             }
 
-            bool hasPROCEDURE = false;
-            if (command.CommandText != null && command.CommandText.ToUpper().IndexOf("PROCEDURE") >= 0)
-            {
-                hasPROCEDURE = true;
-            }
-
             foreach (var param in parameters.Values)
             {
                 if (param.CameFromTemplate) continue;
@@ -258,15 +250,7 @@ namespace Dapper
                 }
                 else
                 {
-                    bool add;
-                    if (hasPROCEDURE)
-                    {
-                        add = !command.Parameters.Contains(name);
-                    }
-                    else
-                    {
-                        add = !cleanNames.Contains(name);
-                    }
+                    bool add = !command.Parameters.Contains(name);
                     IDbDataParameter p;
                     if (add)
                     {

--- a/Dapper/DynamicParameters.cs
+++ b/Dapper/DynamicParameters.cs
@@ -293,7 +293,6 @@ namespace Dapper
                     if (add)
                     {
                         command.Parameters.Add(p);
-                        cleanNames.Add(name);
                     }
                     param.AttachedParam = p;
                 }

--- a/Dapper/DynamicParameters.cs
+++ b/Dapper/DynamicParameters.cs
@@ -250,7 +250,7 @@ namespace Dapper
                 }
                 else
                 {
-                    bool add = !command.Parameters.Contains(name);
+                    bool add = !parameters.ContainsKey(param.Name);
                     IDbDataParameter p;
                     if (add)
                     {

--- a/Dapper/DynamicParameters.cs
+++ b/Dapper/DynamicParameters.cs
@@ -262,7 +262,7 @@ namespace Dapper
                     bool add;
                     if (hasPROCEDURE)
                     {
-                        add = command.Parameters.Contains(name);
+                        add = !command.Parameters.Contains(name);
                     }
                     else
                     {

--- a/Dapper/DynamicParameters.cs
+++ b/Dapper/DynamicParameters.cs
@@ -210,7 +210,6 @@ namespace Dapper
                             Size = param.Size,
                             Value = param.Value
                         });
-                        cleanNames.Add(Clean(param.ParameterName));
                     }
                 }
 
@@ -226,7 +225,7 @@ namespace Dapper
             }
 
             bool hasPROCEDURE = false;
-            if (command.CommandText.ToUpper().IndexOf("PROCEDURE") >= 0)
+            if (command.CommandText != null && command.CommandText.ToUpper().IndexOf("PROCEDURE") >= 0)
             {
                 hasPROCEDURE = true;
             }

--- a/Dapper/DynamicParameters.cs
+++ b/Dapper/DynamicParameters.cs
@@ -248,14 +248,6 @@ namespace Dapper
 #pragma warning disable 612, 618
                     SqlMapper.PackListParameters(command, name, val);
 #pragma warning restore 612, 618
-                    foreach (IDbDataParameter paramItem in command.Parameters)
-                    {
-                        string cleanName = Clean(paramItem.ParameterName);
-                        if (!cleanNames.Contains(cleanName))
-                        {
-                            cleanNames.Add(cleanName);
-                        }
-                    }
                 }
                 else
                 {

--- a/Dapper/DynamicParameters.cs
+++ b/Dapper/DynamicParameters.cs
@@ -296,6 +296,7 @@ namespace Dapper
                     if (add)
                     {
                         command.Parameters.Add(p);
+                        cleanNames.Add(name);
                     }
                     param.AttachedParam = p;
                 }

--- a/Dapper/DynamicParameters.cs
+++ b/Dapper/DynamicParameters.cs
@@ -16,6 +16,7 @@ namespace Dapper
         internal const DbType EnumerableMultiParameter = (DbType)(-1);
         private static readonly Dictionary<SqlMapper.Identity, Action<IDbCommand, object>> paramReaderCache = new Dictionary<SqlMapper.Identity, Action<IDbCommand, object>>();
         private readonly Dictionary<string, ParamInfo> parameters = new Dictionary<string, ParamInfo>();
+        private readonly HashSet<string> cleanNames = new HashSet<string>();
         private List<object> templates;
 
         object SqlMapper.IParameterLookup.this[string name] =>
@@ -250,7 +251,7 @@ namespace Dapper
                 }
                 else
                 {
-                    bool add = !command.Parameters.Contains(name);
+                    bool add = !cleanNames.Contains(name);
                     IDbDataParameter p;
                     if (add)
                     {
@@ -293,6 +294,7 @@ namespace Dapper
                     if (add)
                     {
                         command.Parameters.Add(p);
+                        cleanNames.Add(name);
                     }
                     param.AttachedParam = p;
                 }

--- a/Dapper/DynamicParameters.cs
+++ b/Dapper/DynamicParameters.cs
@@ -225,6 +225,12 @@ namespace Dapper
                 }
             }
 
+            bool hasPROCEDURE = false;
+            if (command.CommandText.ToUpper().IndexOf("PROCEDURE") >= 0)
+            {
+                hasPROCEDURE = true;
+            }
+
             foreach (var param in parameters.Values)
             {
                 if (param.CameFromTemplate) continue;
@@ -253,7 +259,15 @@ namespace Dapper
                 }
                 else
                 {
-                    bool add = !cleanNames.Contains(name);
+                    bool add;
+                    if (hasPROCEDURE)
+                    {
+                        add = command.Parameters.Contains(name);
+                    }
+                    else
+                    {
+                        add = !cleanNames.Contains(name);
+                    }
                     IDbDataParameter p;
                     if (add)
                     {

--- a/Dapper/DynamicParameters.cs
+++ b/Dapper/DynamicParameters.cs
@@ -248,6 +248,14 @@ namespace Dapper
 #pragma warning disable 612, 618
                     SqlMapper.PackListParameters(command, name, val);
 #pragma warning restore 612, 618
+                    foreach (IDbDataParameter paramItem in command.Parameters)
+                    {
+                        string cleanName = Clean(paramItem.ParameterName);
+                        if (!cleanNames.Contains(cleanName))
+                        {
+                            cleanNames.Add(cleanName);
+                        }
+                    }
                 }
                 else
                 {

--- a/Dapper/DynamicParameters.cs
+++ b/Dapper/DynamicParameters.cs
@@ -223,6 +223,14 @@ namespace Dapper
                 }
             }
 
+            foreach (IDbDataParameter param in command.Parameters)
+            {
+                if (!cleanNames.Contains(param.ParameterName))
+                {
+                    cleanNames.Add(param.ParameterName);
+                }
+            }
+
             foreach (var param in parameters.Values)
             {
                 if (param.CameFromTemplate) continue;

--- a/Dapper/DynamicParameters.cs
+++ b/Dapper/DynamicParameters.cs
@@ -170,6 +170,8 @@ namespace Dapper
         {
             var literals = SqlMapper.GetLiteralTokens(identity.sql);
 
+            HashSet<string> cleanNames = new HashSet<string>();
+
             if (templates != null)
             {
                 foreach (var template in templates)
@@ -208,6 +210,7 @@ namespace Dapper
                             Size = param.Size,
                             Value = param.Value
                         });
+                        cleanNames.Add(Clean(param.ParameterName));
                     }
                 }
 
@@ -250,7 +253,7 @@ namespace Dapper
                 }
                 else
                 {
-                    bool add = !parameters.ContainsKey(param.Name);
+                    bool add = !cleanNames.Contains(name);
                     IDbDataParameter p;
                     if (add)
                     {


### PR DESCRIPTION
Used for batch insert by one SQL statement.

issue: [https://github.com/DapperLib/Dapper/issues/1817](https://github.com/DapperLib/Dapper/issues/1817)

Myself Test Engineering：https://github.com/0611163/Dapper.LiteSql --> PostgreSQLTest --> public void Test2InsertList() --> conn.Execute(strSql.ToString(), ToDynamicParameters(parameters), _tran)
