### PR TITLE
Fix IDataReader.GetRowParser<string>() throws exception #1822

### DIFF
--- a/Dapper/SqlMapper.IDataReader.cs
+++ b/Dapper/SqlMapper.IDataReader.cs
@@ -140,14 +140,11 @@ namespace Dapper
         {
             concreteType ??= typeof(T);
             var func = GetDeserializer(concreteType, reader, startIndex, length, returnNullIfFirstMissing);
-            if (concreteType.IsValueType)
-            {
+            if (func.Method.ReturnType != typeof(T))
+            { // Always use a wrapper: this works for value and ref types (delegate casting is not an option).
                 return _ => (T)func(_);
             }
-            else
-            {
-                return (Func<IDataReader, T>)(Delegate)func;
-            }
+            return (Func<IDataReader, T>)(Delegate)func;
         }
     }
 }

--- a/tests/Dapper.Tests/DataReaderTests.cs
+++ b/tests/Dapper.Tests/DataReaderTests.cs
@@ -146,6 +146,21 @@ select 'def' as Name, 2 as Type, 4.0 as Value, 2 as Id, 'qwe' as Name"))
             Assert.Equal("qwe", bar.HazNameIdObject.Name);
         }
 
+        /// <summary>
+        /// See https://github.com/DapperLib/Dapper/issues/1822
+        /// </summary>
+        [Fact]
+        public void issue_number_1822()
+        {
+            var reader = connection.ExecuteReader("select 'test' as col");
+            var rowParser = reader.GetRowParser<string>();
+
+            reader.Read();
+            // This should not throw!
+            string result = rowParser(reader);
+            Assert.Equal("test", result);
+        }
+
         private abstract class Discriminated_BaseType
         {
             public abstract int Type { get; }


### PR DESCRIPTION
Fix #1822.
The new test along with a presentation of this fix is here:  https://github.com/DapperLib/Dapper/issues/1822#issuecomment-1254715993
