### PR TITLE
add: tests for CockroachDB

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,13 +1,9 @@
 name: Main Build
 
 on:
-  pull_request:
   push:
     branches:
     - main
-    paths:
-    - '*'
-    - '!/docs/*' # Don't run workflow when files are only in the /docs directory
 
 jobs:
   vm-job:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,10 @@ jobs:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: test
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+      cockroachdb:
+        image: timveil/cockroachdb-single-node:latest
+        ports:
+          - 26257:26257
       sqlserver:
         image: mcr.microsoft.com/mssql/server:2019-latest
         ports:
@@ -38,8 +42,15 @@ jobs:
           MYSQL_ROOT_PASSWORD: root
           MYSQL_DATABASE: test
     steps:
+
     - name: Checkout code
       uses: actions/checkout@v1
+    - name: .NET setup
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: |
+          3.1.x
+          5.0.x
     - name: .NET Build
       run: dotnet build Build.csproj -c Release /p:CI=true
     - name: Dapper Tests

--- a/tests/Dapper.Tests/Providers/CockroachDBTests.cs
+++ b/tests/Dapper.Tests/Providers/CockroachDBTests.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Linq;
+using Xunit;
+
+namespace Dapper.Tests
+{
+    public class CockroachDBProvider : DatabaseProvider
+    {
+        public override DbProviderFactory Factory => Npgsql.NpgsqlFactory.Instance;
+        public override string GetConnectionString() =>
+            GetConnectionString("CockroachDBConnectionString", "Server=localhost;Port=26257;User Id=root;Database=defaultdb");
+    }
+    public class CockroachDBTests : TestBase<CockroachDBProvider>
+    {
+        private Npgsql.NpgsqlConnection GetOpenNpgsqlConnection() => (Npgsql.NpgsqlConnection)Provider.GetOpenConnection();
+
+        private class Cat
+        {
+            public Int64 Id { get; set; }
+            public string Breed { get; set; }
+            public string Name { get; set; }
+        }
+
+        private readonly Cat[] Cats =
+        {
+            new Cat() { Breed = "Abyssinian", Name="KACTUS"},
+            new Cat() { Breed = "Aegean cat", Name="KADAFFI"},
+            new Cat() { Breed = "American Bobtail", Name="KANJI"},
+            new Cat() { Breed = "Balinese", Name="MACARONI"},
+            new Cat() { Breed = "Bombay", Name="MACAULAY"},
+            new Cat() { Breed = "Burmese", Name="MACBETH"},
+            new Cat() { Breed = "Chartreux", Name="MACGYVER"},
+            new Cat() { Breed = "German Rex", Name="MACKENZIE"},
+            new Cat() { Breed = "Javanese", Name="MADISON"},
+            new Cat() { Breed = "Persian", Name="MAGNA"}
+        };
+
+        [FactCockroachDB]
+        public void TestCockroachDBArrayParameters()
+        {
+            using (var conn = GetOpenNpgsqlConnection())
+            {
+                IDbTransaction transaction = conn.BeginTransaction();
+                conn.Execute("create table tcat ( id serial not null, breed character varying(20) not null, name character varying (20) not null);");
+                conn.Execute("insert into tcat(breed, name) values(:Breed, :Name) ", Cats);
+                var r = conn.Query<Cat>("select * from tcat;");
+                Assert.Equal(10, r.Count());
+                transaction.Rollback();
+            }
+        }
+
+        [FactCockroachDB]
+        public void TestCockroachDBListParameters()
+        {
+            using (var conn = GetOpenNpgsqlConnection())
+            {
+                IDbTransaction transaction = conn.BeginTransaction();
+                conn.Execute("create table tcat ( id serial not null, breed character varying(20) not null, name character varying (20) not null);");
+                conn.Execute("insert into tcat(breed, name) values(:Breed, :Name) ", new List<Cat>(Cats));
+
+                var r = conn.Query<Cat>("select * from tcat;");
+                Assert.Equal(10, r.Count());
+                transaction.Rollback();
+            }
+        }
+
+        private class CharTable
+        {
+            public Int64 Id { get; set; }
+            public char CharColumn { get; set; }
+        }
+
+        [FactCockroachDB]
+        public void TestCockroachDBChar()
+        {
+            using (var conn = GetOpenNpgsqlConnection())
+            {
+                var transaction = conn.BeginTransaction();
+                conn.Execute("create table chartable (id serial not null, charcolumn \"char\" not null);");
+                conn.Execute("insert into chartable(charcolumn) values('a');");
+
+                var r = conn.Query<CharTable>("select * from chartable");
+                Assert.Single(r);
+                Assert.Equal('a', r.Single().CharColumn);
+                transaction.Rollback();
+            }
+        }
+
+        [FactCockroachDB]
+        public void TestCockroachDBSelectArray()
+        {
+            using (var conn = GetOpenNpgsqlConnection())
+            {
+                var r = conn.Query<int[]>("select array[1,2,3]").ToList();
+                Assert.Single(r);
+                Assert.Equal(new[] { 1, 2, 3 }, r.Single());
+            }
+        }
+
+        [FactCockroachDB]
+        public void TestCockroachDBDateTimeUsage()
+        {
+            using (var conn = GetOpenNpgsqlConnection())
+            {
+                DateTime now = DateTime.UtcNow;
+                DateTime? nilA = now, nilB = null;
+                _ = conn.ExecuteScalar("SELECT @now, @nilA, @nilB::timestamp", new { now, nilA, nilB });
+            }
+        }
+
+        [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+        public class FactCockroachDBAttribute : FactAttribute
+        {
+            public override string Skip
+            {
+                get { return unavailable ?? base.Skip; }
+                set { base.Skip = value; }
+            }
+
+            private static readonly string unavailable;
+
+            static FactCockroachDBAttribute()
+            {
+                try
+                {
+                    using (DatabaseProvider<CockroachDBProvider>.Instance.GetOpenConnection()) { /* just trying to see if it works */ }
+                }
+                catch (Exception ex)
+                {
+                    unavailable = $"CockroachDB is unavailable: {ex.Message}";
+                }
+            }
+        }
+    }
+}

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -17,6 +17,12 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: test
+  cockroachdb:
+    image: cockroachdb/cockroach:v22.2.1
+    container_name: cockroachdb
+    command: start-single-node --insecure
+    ports:
+      - 26257:26257
   sqlserver:
     image: mcr.microsoft.com/mssql/server:2019-latest
     container_name: sql-server-db


### PR DESCRIPTION
This PR adds tests for CockroachDB. The tests are largely borrowed from the existing PostgreSQL tests to ensure basic functionality. [Due to the way SERIAL](https://www.cockroachlabs.com/docs/stable/serial.html) primary keys work in CockroachDB some tests had to be removed because they were no longer deterministic.

The official CockroachDB docker image [has issues](https://github.com/cockroachdb/cockroach/discussions/83749) starting in single node mode in Actions CI, so an [alternate image](https://github.com/cockroachlabs-field/cockroachdb-single-node) had to be used.

Finally, I was running into issues with .NET framework versions missing for 3.x and 5.x so I modified the CI to include those versions.