### PR TITLE
add 'TrySetTypeMap' method

### DIFF
--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -3070,6 +3070,23 @@ namespace Dapper
         }
 
         /// <summary>
+        /// Try set custom mapping for type deserializers.
+        /// If type mapping has already been set, it is not set repeatedly.
+        /// </summary>
+        /// <param name="type"></param>
+        /// <param name="map"></param>
+        /// <returns>If type mapping has already been set, it will return false ,else return true.</returns>
+        public static bool TrySetTypeMap(Type type, ITypeMap map)
+        {
+            if (_typeMaps.ContainsKey(type))
+            {
+                return false;
+            }
+            SetTypeMap(type, map);
+            return true;
+        }
+
+        /// <summary>
         /// Internal use only
         /// </summary>
         /// <param name="type"></param>


### PR DESCRIPTION
Add 'TrySetTypeMap' method. This allows you to add type mappings on demand, without having to add type mappings at initialization time or maintain type mapping tables locally.

eg:
```csharp
protected async Task<IEnumerable<T>> QueryAsync<T>(string sql, object? param = null)
{
    //Use 'TrySetTypeMap' to avoid duplicate settings.
    SqlMapper.TrySetTypeMap(typeof(T), new CustomPropertyTypeMap(typeof(T), (type, name) => type.GetProperties().FirstOrDefault(prop => CaseHelper.ToSnakeCase(prop.Name) == name)));

    await using var connection = await _dataSource.OpenConnectionAsync();
    var list = await connection.QueryAsync<T>(sql, param);
    return list;
}
```