### PR TITLE
Issue #1239 resolution - QueryAsync missing buffered parameter

### DIFF
--- a/Dapper.EntityFramework.StrongName/Dapper.EntityFramework.StrongName.csproj
+++ b/Dapper.EntityFramework.StrongName/Dapper.EntityFramework.StrongName.csproj
@@ -4,7 +4,7 @@
     <Title>Dapper: Entity Framework type handlers (with a strong name)</Title>
     <Description>Extension handlers for entity framework</Description>
     <Authors>Marc Gravell;Nick Craver</Authors>
-    <TargetFrameworks>net461</TargetFrameworks>
+    <TargetFrameworks>net462</TargetFrameworks>
     <AssemblyOriginatorKeyFile>../Dapper.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>

--- a/Dapper.EntityFramework/Dapper.EntityFramework.csproj
+++ b/Dapper.EntityFramework/Dapper.EntityFramework.csproj
@@ -5,7 +5,7 @@
     <AssemblyTitle>Dapper entity framework type handlers</AssemblyTitle>
     <VersionPrefix>1.50.2</VersionPrefix>
     <Authors>Marc Gravell;Nick Craver</Authors>
-    <TargetFrameworks>net461</TargetFrameworks>
+    <TargetFrameworks>net462</TargetFrameworks>
     <PackageTags>orm;sql;micro-orm</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/Dapper.Rainbow/Dapper.Rainbow.csproj
+++ b/Dapper.Rainbow/Dapper.Rainbow.csproj
@@ -6,17 +6,18 @@
     <Description>Trivial micro-orm implemented on Dapper, provides with CRUD helpers.</Description>
     <Authors>Sam Saffron</Authors>
     <Copyright>2017 Sam Saffron</Copyright>
-    <TargetFrameworks>net461;netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>net48;netstandard2.1;net5.0</TargetFrameworks>
     <!-- TODO: Docs -->
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Dapper\Dapper.csproj" />
+    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 </Project>

--- a/Dapper.Rainbow/Database.Async.cs
+++ b/Dapper.Rainbow/Database.Async.cs
@@ -26,7 +26,7 @@ namespace Dapper
                 string colsParams = string.Join(",", paramNames.Select(p => "@" + p));
                 var sql = "set nocount on insert " + TableName + " (" + cols + ") values (" + colsParams + ") select cast(scope_identity() as int)";
 
-                return (await database.QueryAsync<int?>(sql, o).ConfigureAwait(false)).Single();
+                return await database.QueryAsync<int?>(sql, o).SingleAsync().ConfigureAwait(false);
             }
 
             /// <summary>
@@ -77,7 +77,7 @@ namespace Dapper
             /// Asynchronously gets the all rows from this table.
             /// </summary>
             /// <returns>Data from all table rows.</returns>
-            public Task<IEnumerable<T>> AllAsync() =>
+            public IAsyncEnumerable<T> AllAsync() =>
                 database.QueryAsync<T>("select * from " + TableName);
         }
 
@@ -97,7 +97,7 @@ namespace Dapper
         /// <param name="sql">The SQL to execute.</param>
         /// <param name="param">The parameters to use.</param>
         /// <returns>An enumerable of <typeparamref name="T"/> for the rows fetched.</returns>
-        public Task<IEnumerable<T>> QueryAsync<T>(string sql, dynamic param = null) =>
+        public IAsyncEnumerable<T> QueryAsync<T>(string sql, dynamic param = null) =>
             _connection.QueryAsync<T>(sql, param as object, _transaction, _commandTimeout);
 
         /// <summary>
@@ -194,7 +194,7 @@ namespace Dapper
         /// <param name="sql">The SQL to execute.</param>
         /// <param name="param">The parameters to use.</param>
         /// <remarks>Note: each row can be accessed via "dynamic", or by casting to an IDictionary&lt;string,object&gt;</remarks>
-        public Task<IEnumerable<dynamic>> QueryAsync(string sql, dynamic param = null) =>
+        public IAsyncEnumerable<dynamic> QueryAsync(string sql, dynamic param = null) =>
             _connection.QueryAsync(sql, param as object, _transaction);
 
         /// <summary>

--- a/Dapper.SqlBuilder/Dapper.SqlBuilder.csproj
+++ b/Dapper.SqlBuilder/Dapper.SqlBuilder.csproj
@@ -5,17 +5,17 @@
     <Title>Dapper SqlBuilder component</Title>
     <Description>The Dapper SqlBuilder component, for building SQL queries dynamically.</Description>
     <Authors>Sam Saffron, Johan Danforth</Authors>
-    <TargetFrameworks>net461;netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.1;net5.0</TargetFrameworks>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Dapper\Dapper.csproj" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 </Project>

--- a/Dapper.StrongName/Dapper.StrongName.csproj
+++ b/Dapper.StrongName/Dapper.StrongName.csproj
@@ -5,7 +5,7 @@
     <Title>Dapper (Strong Named)</Title>
     <Description>A high performance Micro-ORM supporting SQL Server, MySQL, Sqlite, SqlCE, Firebird etc..</Description>
     <Authors>Sam Saffron;Marc Gravell;Nick Craver</Authors>
-    <TargetFrameworks>net461;netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.1;net5.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
   </PropertyGroup>
@@ -22,7 +22,7 @@
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461'">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net462'">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
   </ItemGroup>
 </Project>

--- a/Dapper.StrongName/Dapper.StrongName.csproj
+++ b/Dapper.StrongName/Dapper.StrongName.csproj
@@ -5,7 +5,7 @@
     <Title>Dapper (Strong Named)</Title>
     <Description>A high performance Micro-ORM supporting SQL Server, MySQL, Sqlite, SqlCE, Firebird etc..</Description>
     <Authors>Sam Saffron;Marc Gravell;Nick Craver</Authors>
-    <TargetFrameworks>net461;netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.1;net5.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
   </PropertyGroup>
@@ -18,7 +18,11 @@
     <DefineConstants>$(DefineConstants);PLAT_NO_REMOTING;PLAT_SKIP_LOCALS_INIT</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1'">
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461'">
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
   </ItemGroup>
 </Project>

--- a/Dapper/Dapper.csproj
+++ b/Dapper/Dapper.csproj
@@ -5,7 +5,7 @@
     <PackageTags>orm;sql;micro-orm</PackageTags>
     <Description>A high performance Micro-ORM supporting SQL Server, MySQL, Sqlite, SqlCE, Firebird etc..</Description>
     <Authors>Sam Saffron;Marc Gravell;Nick Craver</Authors>
-    <TargetFrameworks>net461;netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Folder Include="Properties\" />
@@ -15,7 +15,11 @@
     <DefineConstants>$(DefineConstants);PLAT_NO_REMOTING;PLAT_SKIP_LOCALS_INIT</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1'">
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461'">
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
   </ItemGroup>
 </Project>

--- a/Dapper/Dapper.csproj
+++ b/Dapper/Dapper.csproj
@@ -5,7 +5,7 @@
     <PackageTags>orm;sql;micro-orm</PackageTags>
     <Description>A high performance Micro-ORM supporting SQL Server, MySQL, Sqlite, SqlCE, Firebird etc..</Description>
     <Authors>Sam Saffron;Marc Gravell;Nick Craver</Authors>
-    <TargetFrameworks>net461;netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Folder Include="Properties\" />
@@ -19,7 +19,7 @@
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461'">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net462'">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
   </ItemGroup>
 </Project>

--- a/Dapper/SqlMapper.Async.cs
+++ b/Dapper/SqlMapper.Async.cs
@@ -19,11 +19,12 @@ namespace Dapper
         /// <param name="sql">The SQL to execute for the query.</param>
         /// <param name="param">The parameters to pass, if any.</param>
         /// <param name="transaction">The transaction to use, if any.</param>
+        /// <param name="buffered">Whether to buffer the results in memory.</param>
         /// <param name="commandTimeout">The command timeout (in seconds).</param>
         /// <param name="commandType">The type of command to execute.</param>
         /// <remarks>Note: each row can be accessed via "dynamic", or by casting to an IDictionary&lt;string,object&gt;</remarks>
-        public static IAsyncEnumerable<dynamic> QueryAsync(this IDbConnection cnn, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null) =>
-            QueryAsync<dynamic>(cnn, typeof(DapperRow), new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.Buffered, default));
+        public static IAsyncEnumerable<dynamic> QueryAsync(this IDbConnection cnn, string sql, object param = null, IDbTransaction transaction = null, bool buffered = true, int ? commandTimeout = null, CommandType? commandType = null) =>
+            QueryAsync<dynamic>(cnn, typeof(DapperRow), new CommandDefinition(sql, param, transaction, commandTimeout, commandType, buffered ? CommandFlags.Buffered : CommandFlags.None, default));
 
         /// <summary>
         /// Execute a query asynchronously using Task.
@@ -195,13 +196,14 @@ namespace Dapper
         /// <param name="sql">The SQL to execute for the query.</param>
         /// <param name="param">The parameters to pass, if any.</param>
         /// <param name="transaction">The transaction to use, if any.</param>
+        /// <param name="buffered">Whether to buffer the results in memory.</param>
         /// <param name="commandTimeout">The command timeout (in seconds).</param>
         /// <param name="commandType">The type of command to execute.</param>
         /// <exception cref="ArgumentNullException"><paramref name="type"/> is <c>null</c>.</exception>
-        public static IAsyncEnumerable<object> QueryAsync(this IDbConnection cnn, Type type, string sql, object param = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static IAsyncEnumerable<object> QueryAsync(this IDbConnection cnn, Type type, string sql, object param = null, IDbTransaction transaction = null, bool buffered = true, int ? commandTimeout = null, CommandType? commandType = null)
         {
             if (type == null) throw new ArgumentNullException(nameof(type));
-            return QueryAsync<object>(cnn, type, new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.Buffered, default));
+            return QueryAsync<object>(cnn, type, new CommandDefinition(sql, param, transaction, commandTimeout, commandType, buffered ? CommandFlags.Buffered : CommandFlags.None, default));
         }
 
         /// <summary>

--- a/tests/Dapper.Tests/AsyncTests.cs
+++ b/tests/Dapper.Tests/AsyncTests.cs
@@ -246,8 +246,10 @@ namespace Dapper.Tests
         {
             using (SqlMapper.GridReader multi = await connection.QueryMultipleAsync("select 1; select 2").ConfigureAwait(false))
             {
-                Assert.Equal(1, multi.ReadAsync<int>().Result.Single());
-                Assert.Equal(2, multi.ReadAsync<int>().Result.Single());
+                var first = await multi.ReadAsync<int>().SingleAsync().ConfigureAwait(false);
+                Assert.Equal(1, first);
+                var second = await multi.ReadAsync<int>().SingleAsync().ConfigureAwait(false);
+                Assert.Equal(2, second);
             }
         }
 
@@ -256,8 +258,10 @@ namespace Dapper.Tests
         {
             using (SqlMapper.GridReader multi = await connection.QueryMultipleAsync("select Cast(1 as BigInt) Col1; select Cast(2 as BigInt) Col2").ConfigureAwait(false))
             {
-                Assert.Equal(1, multi.ReadAsync<int>().Result.Single());
-                Assert.Equal(2, multi.ReadAsync<int>().Result.Single());
+                var first = await multi.ReadAsync<int>().SingleAsync().ConfigureAwait(false);
+                Assert.Equal(1, first);
+                var second = await multi.ReadAsync<int>().SingleAsync().ConfigureAwait(false);
+                Assert.Equal(2, second);
             }
         }
 
@@ -267,9 +271,11 @@ namespace Dapper.Tests
             using (SqlMapper.GridReader multi = await connection.QueryMultipleAsync("select 1; select 2; select 3; select 4; select 5").ConfigureAwait(false))
             {
                 Assert.Equal(1, multi.ReadFirstOrDefaultAsync<int>().Result);
-                Assert.Equal(2, multi.ReadAsync<int>().Result.Single());
+                var second = await multi.ReadAsync<int>().SingleAsync().ConfigureAwait(false);
+                Assert.Equal(2, second);
                 Assert.Equal(3, multi.ReadFirstOrDefaultAsync<int>().Result);
-                Assert.Equal(4, multi.ReadAsync<int>().Result.Single());
+                var fourth = await multi.ReadAsync<int>().SingleAsync().ConfigureAwait(false);
+                Assert.Equal(4, fourth);
                 Assert.Equal(5, multi.ReadFirstOrDefaultAsync<int>().Result);
             }
         }
@@ -281,8 +287,8 @@ namespace Dapper.Tests
             {
                 using (SqlMapper.GridReader multi = await conn.QueryMultipleAsync("select 1; select 2").ConfigureAwait(false))
                 {
-                    Assert.Equal(1, multi.ReadAsync<int>().Result.Single());
-                    Assert.Equal(2, multi.ReadAsync<int>().Result.Single());
+                    Assert.Equal(1, await multi.ReadAsync<int>().SingleAsync().ConfigureAwait(false));
+                    Assert.Equal(2, await multi.ReadAsync<int>().SingleAsync().ConfigureAwait(false));
                 }
             }
         }
@@ -295,9 +301,11 @@ namespace Dapper.Tests
                 using (SqlMapper.GridReader multi = await conn.QueryMultipleAsync("select 1; select 2; select 3; select 4; select 5").ConfigureAwait(false))
                 {
                     Assert.Equal(1, multi.ReadFirstOrDefaultAsync<int>().Result);
-                    Assert.Equal(2, multi.ReadAsync<int>().Result.Single());
+                    var second = await multi.ReadAsync<int>().SingleAsync().ConfigureAwait(false);
+                    Assert.Equal(2, second);
                     Assert.Equal(3, multi.ReadFirstOrDefaultAsync<int>().Result);
-                    Assert.Equal(4, multi.ReadAsync<int>().Result.Single());
+                    var fourth = await multi.ReadAsync<int>().SingleAsync().ConfigureAwait(false);
+                    Assert.Equal(4, fourth);
                     Assert.Equal(5, multi.ReadFirstOrDefaultAsync<int>().Result);
                 }
             }
@@ -691,8 +699,8 @@ select 42
 select 17
 SET @AddressPersonId = @PersonId", p).ConfigureAwait(false))
             {
-                x = multi.ReadAsync<int>().Result.Single();
-                y = multi.ReadAsync<int>().Result.Single();
+                x = await multi.ReadAsync<int>().SingleAsync().ConfigureAwait(false);
+                y = await multi.ReadAsync<int>().SingleAsync().ConfigureAwait(false);
             }
 
             Assert.Equal("grillmaster", bob.Occupation);

--- a/tests/Dapper.Tests/Dapper.Tests.csproj
+++ b/tests/Dapper.Tests/Dapper.Tests.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="Snowflake.Data" Version="2.0.3" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net472'">

--- a/tests/Dapper.Tests/MiscTests.cs
+++ b/tests/Dapper.Tests/MiscTests.cs
@@ -220,7 +220,7 @@ namespace Dapper.Tests
             // List paths
             var list = connection.Query<int?>(sql);
             Assert.Null(Assert.Single(list));
-            list = await connection.QueryAsync<int?>(sql);
+            list = await connection.QueryAsync<int?>(sql).ToListAsync();
             Assert.Null(Assert.Single(list));
 
             // Single row paths
@@ -247,7 +247,7 @@ namespace Dapper.Tests
                 ex = Assert.Throws<DataException>(() => connection.QuerySingleOrDefault<T>(sql));
                 Assert.Equal(exception, ex.Message);
 
-                ex = await Assert.ThrowsAsync<DataException>(() => connection.QueryAsync<T>(sql));
+                ex = await Assert.ThrowsAsync<DataException>(async () => await connection.QueryAsync<T>(sql).ToListAsync());
                 Assert.Equal(exception, ex.Message);
                 ex = await Assert.ThrowsAsync<DataException>(() => connection.QueryFirstAsync<T>(sql));
                 Assert.Equal(exception, ex.Message);
@@ -1237,8 +1237,10 @@ create table TPTable (Pid int not null primary key identity(1,1), Value int not 
 insert TPTable (Value) values (2), (568)");
 
             // fetch the data using the query in the question, then force to a dictionary
-            var rows = (await connection.QueryAsync<TPTable>("select * from TPTable").ConfigureAwait(false))
-                .ToDictionary(x => x.Pid);
+            var rows = 
+                await connection.QueryAsync<TPTable>("select * from TPTable")
+                .ToDictionaryAsync(x => x.Pid)
+                .ConfigureAwait(false);
 
             // check the number of rows
             Assert.Equal(2, rows.Count);

--- a/tests/Dapper.Tests/ProcedureTests.cs
+++ b/tests/Dapper.Tests/ProcedureTests.cs
@@ -277,7 +277,8 @@ namespace Dapper.Tests
                 end
             end
             
-            exec {tempSPName}");
+            exec {tempSPName}")
+                .ToListAsync();
 
             Assert.Empty(result);
         }

--- a/tests/Dapper.Tests/Providers/SqliteTests.cs
+++ b/tests/Dapper.Tests/Providers/SqliteTests.cs
@@ -74,9 +74,15 @@ namespace Dapper.Tests
             using (var connection = GetSQLiteConnection())
             {
                 SqlMapper.ResetTypeHandlers();
-                var row = (await connection.QueryAsync<HazNameId>("select 42 as Id").ConfigureAwait(false)).First();
+                var row = 
+                    await connection.QueryAsync<HazNameId>("select 42 as Id")
+                    .FirstAsync()
+                    .ConfigureAwait(false);
                 Assert.Equal(42, row.Id);
-                row = (await connection.QueryAsync<HazNameId>("select 42 as Id").ConfigureAwait(false)).First();
+                row = 
+                    await connection.QueryAsync<HazNameId>("select 42 as Id")
+                    .FirstAsync()
+                    .ConfigureAwait(false);
                 Assert.Equal(42, row.Id);
 
                 SqlMapper.ResetTypeHandlers();


### PR DESCRIPTION
This change resolves https://github.com/DapperLib/Dapper/issues/1239.

I had to switch to net48;netstandard2.1 because of the Microsoft.Bcl.AsyncInterfaces and System.Linq.Async packages, but I think it's worth it.