### PR TITLE
add support for fetching values via GetFieldValue<T>

### DIFF
--- a/Dapper/SqlMapper.Async.cs
+++ b/Dapper/SqlMapper.Async.cs
@@ -967,7 +967,7 @@ namespace Dapper
             }
         }
 
-        private static IEnumerable<T> ExecuteReaderSync<T>(IDataReader reader, Func<IDataReader, object> func, object parameters)
+        private static IEnumerable<T> ExecuteReaderSync<T>(DbDataReader reader, Func<DbDataReader, object> func, object parameters)
         {
             using (reader)
             {
@@ -1004,7 +1004,7 @@ namespace Dapper
             CacheInfo info = GetCacheInfo(identity, param, command.AddToCache);
 
             DbCommand cmd = null;
-            IDataReader reader = null;
+            DbDataReader reader = null;
             bool wasClosed = cnn.State == ConnectionState.Closed;
             try
             {

--- a/Dapper/SqlMapper.CacheInfo.cs
+++ b/Dapper/SqlMapper.CacheInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Data;
+using System.Data.Common;
 using System.Threading;
 
 namespace Dapper
@@ -9,7 +10,7 @@ namespace Dapper
         private class CacheInfo
         {
             public DeserializerState Deserializer { get; set; }
-            public Func<IDataReader, object>[] OtherDeserializers { get; set; }
+            public Func<DbDataReader, object>[] OtherDeserializers { get; set; }
             public Action<IDbCommand, object> ParamReader { get; set; }
             private int hitCount;
             public int GetHitCount() { return Interlocked.CompareExchange(ref hitCount, 0, 0); }

--- a/Dapper/SqlMapper.DeserializerState.cs
+++ b/Dapper/SqlMapper.DeserializerState.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Data;
+using System.Data.Common;
 
 namespace Dapper
 {
@@ -8,9 +9,9 @@ namespace Dapper
         private struct DeserializerState
         {
             public readonly int Hash;
-            public readonly Func<IDataReader, object> Func;
+            public readonly Func<DbDataReader, object> Func;
 
-            public DeserializerState(int hash, Func<IDataReader, object> func)
+            public DeserializerState(int hash, Func<DbDataReader, object> func)
             {
                 Hash = hash;
                 Func = func;

--- a/Dapper/SqlMapper.GridReader.Async.cs
+++ b/Dapper/SqlMapper.GridReader.Async.cs
@@ -14,7 +14,7 @@ namespace Dapper
         public partial class GridReader
         {
             private readonly CancellationToken cancel;
-            internal GridReader(IDbCommand command, IDataReader reader, Identity identity, DynamicParameters dynamicParams, bool addToCache, CancellationToken cancel)
+            internal GridReader(IDbCommand command, DbDataReader reader, Identity identity, DynamicParameters dynamicParams, bool addToCache, CancellationToken cancel)
                 : this(command, reader, identity, dynamicParams, addToCache)
             {
                 this.cancel = cancel;
@@ -225,7 +225,7 @@ namespace Dapper
                 return result;
             }
 
-            private async Task<IEnumerable<T>> ReadBufferedAsync<T>(int index, Func<IDataReader, object> deserializer)
+            private async Task<IEnumerable<T>> ReadBufferedAsync<T>(int index, Func<DbDataReader, object> deserializer)
             {
                 try
                 {

--- a/Dapper/SqlMapper.GridReader.cs
+++ b/Dapper/SqlMapper.GridReader.cs
@@ -4,6 +4,7 @@ using System.Data;
 using System.Linq;
 using System.Globalization;
 using System.Runtime.CompilerServices;
+using System.Data.Common;
 
 namespace Dapper
 {
@@ -14,11 +15,11 @@ namespace Dapper
         /// </summary>
         public partial class GridReader : IDisposable
         {
-            private IDataReader reader;
+            private DbDataReader reader;
             private readonly Identity identity;
             private readonly bool addToCache;
 
-            internal GridReader(IDbCommand command, IDataReader reader, Identity identity, IParameterCallbacks callbacks, bool addToCache)
+            internal GridReader(IDbCommand command, DbDataReader reader, Identity identity, IParameterCallbacks callbacks, bool addToCache)
             {
                 Command = command;
                 this.reader = reader;
@@ -351,7 +352,7 @@ namespace Dapper
                 return buffered ? result.ToList() : result;
             }
 
-            private IEnumerable<T> ReadDeferred<T>(int index, Func<IDataReader, object> deserializer, Type effectiveType)
+            private IEnumerable<T> ReadDeferred<T>(int index, Func<DbDataReader, object> deserializer, Type effectiveType)
             {
                 try
                 {

--- a/Dapper/SqlMapper.IDataReader.cs
+++ b/Dapper/SqlMapper.IDataReader.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Data.Common;
 
 namespace Dapper
 {
@@ -13,14 +14,15 @@ namespace Dapper
         /// <param name="reader">The data reader to parse results from.</param>
         public static IEnumerable<T> Parse<T>(this IDataReader reader)
         {
-            if (reader.Read())
+            var dbReader = GetDbDataReader(reader, false);
+            if (dbReader.Read())
             {
                 var effectiveType = typeof(T);
-                var deser = GetDeserializer(effectiveType, reader, 0, -1, false);
+                var deser = GetDeserializer(effectiveType, dbReader, 0, -1, false);
                 var convertToType = Nullable.GetUnderlyingType(effectiveType) ?? effectiveType;
                 do
                 {
-                    object val = deser(reader);
+                    object val = deser(dbReader);
                     if (val == null || val is T)
                     {
                         yield return (T)val;
@@ -29,7 +31,7 @@ namespace Dapper
                     {
                         yield return (T)Convert.ChangeType(val, convertToType, System.Globalization.CultureInfo.InvariantCulture);
                     }
-                } while (reader.Read());
+                } while (dbReader.Read());
             }
         }
 
@@ -40,13 +42,14 @@ namespace Dapper
         /// <param name="type">The type to parse from the <paramref name="reader"/>.</param>
         public static IEnumerable<object> Parse(this IDataReader reader, Type type)
         {
-            if (reader.Read())
+            var dbReader = GetDbDataReader(reader, false);
+            if (dbReader.Read())
             {
-                var deser = GetDeserializer(type, reader, 0, -1, false);
+                var deser = GetDeserializer(type, dbReader, 0, -1, false);
                 do
                 {
-                    yield return deser(reader);
-                } while (reader.Read());
+                    yield return deser(dbReader);
+                } while (dbReader.Read());
             }
         }
 
@@ -56,13 +59,14 @@ namespace Dapper
         /// <param name="reader">The data reader to parse results from.</param>
         public static IEnumerable<dynamic> Parse(this IDataReader reader)
         {
-            if (reader.Read())
+            var dbReader = GetDbDataReader(reader, false);
+            if (dbReader.Read())
             {
-                var deser = GetDapperRowDeserializer(reader, 0, -1, false);
+                var deser = GetDapperRowDeserializer(dbReader, 0, -1, false);
                 do
                 {
-                    yield return deser(reader);
-                } while (reader.Read());
+                    yield return deser(dbReader);
+                } while (dbReader.Read());
             }
         }
 
@@ -76,10 +80,45 @@ namespace Dapper
         /// <param name="length">The length of columns to read (default -1 = all fields following startIndex)</param>
         /// <param name="returnNullIfFirstMissing">Return null if we can't find the first column? (default false)</param>
         /// <returns>A parser for this specific object from this row.</returns>
+#if DEBUG // make sure we're not using this internally
+        [Obsolete(nameof(DbDataReader) + " API should be preferred")]
+#endif
         public static Func<IDataReader, object> GetRowParser(this IDataReader reader, Type type,
             int startIndex = 0, int length = -1, bool returnNullIfFirstMissing = false)
         {
+            return WrapObjectReader(GetDeserializer(type, GetDbDataReader(reader, false), startIndex, length, returnNullIfFirstMissing));
+        }
+
+        /// <summary>
+        /// Gets the row parser for a specific row on a data reader. This allows for type switching every row based on, for example, a TypeId column.
+        /// You could return a collection of the base type but have each more specific.
+        /// </summary>
+        /// <param name="reader">The data reader to get the parser for the current row from</param>
+        /// <param name="type">The type to get the parser for</param>
+        /// <param name="startIndex">The start column index of the object (default 0)</param>
+        /// <param name="length">The length of columns to read (default -1 = all fields following startIndex)</param>
+        /// <param name="returnNullIfFirstMissing">Return null if we can't find the first column? (default false)</param>
+        /// <returns>A parser for this specific object from this row.</returns>
+        public static Func<DbDataReader, object> GetRowParser(this DbDataReader reader, Type type,
+            int startIndex = 0, int length = -1, bool returnNullIfFirstMissing = false)
+        {
             return GetDeserializer(type, reader, startIndex, length, returnNullIfFirstMissing);
+        }
+
+        /// <inheritdoc cref="GetRowParser{T}(DbDataReader, Type, int, int, bool)"/>
+#if DEBUG // make sure we're not using this internally
+        [Obsolete(nameof(DbDataReader) + " API should be preferred")]
+#endif
+        public static Func<IDataReader, T> GetRowParser<T>(this IDataReader reader, Type concreteType = null,
+            int startIndex = 0, int length = -1, bool returnNullIfFirstMissing = false)
+        {
+            concreteType ??= typeof(T);
+            var func = GetDeserializer(concreteType, GetDbDataReader(reader, false), startIndex, length, returnNullIfFirstMissing);
+            return Wrap(func);
+
+            // this is just to be very clear about what we're capturing
+            static Func<IDataReader, T> Wrap(Func<DbDataReader, object> func)
+                => reader => (T)func(GetDbDataReader(reader, false));
         }
 
         /// <summary>
@@ -135,7 +174,7 @@ namespace Dapper
         ///     public override int Type =&gt; 2;
         /// }
         /// </example>
-        public static Func<IDataReader, T> GetRowParser<T>(this IDataReader reader, Type concreteType = null,
+        public static Func<DbDataReader, T> GetRowParser<T>(this DbDataReader reader, Type concreteType = null,
             int startIndex = 0, int length = -1, bool returnNullIfFirstMissing = false)
         {
             concreteType ??= typeof(T);
@@ -146,7 +185,7 @@ namespace Dapper
             }
             else
             {
-                return (Func<IDataReader, T>)(Delegate)func;
+                return (Func<DbDataReader, T>)(Delegate)func;
             }
         }
     }

--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -197,7 +197,7 @@ namespace Dapper
 
         static SqlMapper()
         {
-            typeMap = new Dictionary<Type, TypeMapEntry>(21)
+            typeMap = new Dictionary<Type, TypeMapEntry>(41)
             {
                 [typeof(byte)] = DbType.Byte,
                 [typeof(sbyte)] = DbType.SByte,

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,8 +21,9 @@
     <IncludeSymbols>false</IncludeSymbols>
 
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    
+
     <LangVersion>9.0</LangVersion>
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,10 @@ Note: to get the latest pre-release build, add ` -Pre` to the end of the command
 
 ### unreleased
 
+- add support for `SqlDecimal` and other types that need to be accessed via `DbDataReader.GetFieldValue<T>`
+- add an overload of `AddTypeMap` that supports `DbDataReader.GetFieldValue<T>` for additional types
+- acknowledge that in reality we only support `DbDataReader`; this has been true (via `DbConnection`) for `async` forever
+
 (note: new PRs will not be merged until they add release note wording here)
 
 ### 2.0.123

--- a/tests/Dapper.Tests/Dapper.Tests.csproj
+++ b/tests/Dapper.Tests/Dapper.Tests.csproj
@@ -17,7 +17,6 @@
     <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="7.5.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="2.0.1" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="5.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="MySqlConnector" Version="1.1.0" />
     <PackageReference Include="Npgsql" Version="6.0.0" />
     <PackageReference Include="Snowflake.Data" Version="2.0.3" />

--- a/tests/Dapper.Tests/Dapper.Tests.csproj
+++ b/tests/Dapper.Tests/Dapper.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyName>Dapper.Tests</AssemblyName>
     <Description>Dapper Core Test Suite</Description>
-    <TargetFrameworks>netcoreapp3.1;net462;net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net462;net472;net6.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);MSSQLCLIENT</DefineConstants>
     <NoWarn>$(NoWarn);IDE0017;IDE0034;IDE0037;IDE0039;IDE0042;IDE0044;IDE0051;IDE0052;IDE0059;IDE0060;IDE0063;IDE1006;xUnit1004;CA1806;CA1816;CA1822;CA1825;CA2208</NoWarn>
   </PropertyGroup>

--- a/tests/Dapper.Tests/Dapper.Tests.csproj
+++ b/tests/Dapper.Tests/Dapper.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyName>Dapper.Tests</AssemblyName>
     <Description>Dapper Core Test Suite</Description>
-    <TargetFrameworks>netcoreapp3.1;net462;net472;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net462;net472;net6.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);MSSQLCLIENT</DefineConstants>
     <NoWarn>$(NoWarn);IDE0017;IDE0034;IDE0037;IDE0039;IDE0042;IDE0044;IDE0051;IDE0052;IDE0059;IDE0060;IDE0063;IDE1006;xUnit1004;CA1806;CA1816;CA1822;CA1825;CA2208</NoWarn>
   </PropertyGroup>

--- a/tests/Dapper.Tests/DataReaderTests.cs
+++ b/tests/Dapper.Tests/DataReaderTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Data.Common;
 using System.Linq;
 using Xunit;
 
@@ -14,9 +15,46 @@ namespace Dapper.Tests
     public abstract class DataReaderTests<TProvider> : TestBase<TProvider> where TProvider : DatabaseProvider
     {
         [Fact]
-        public void GetSameReaderForSameShape()
+        public void GetSameReaderForSameShape_IDataReader()
         {
             var origReader = connection.ExecuteReader("select 'abc' as Name, 123 as Id");
+#pragma warning disable CS0618 // Type or member is obsolete
+            var origParser = origReader.GetRowParser(typeof(HazNameId));
+
+            var typedParser = origReader.GetRowParser<HazNameId>();
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            // because wrapped for IDataReader, not same instance each time
+            Assert.False(ReferenceEquals(origParser, typedParser));
+
+            var list = origReader.Parse<HazNameId>().ToList();
+            Assert.Single(list);
+            Assert.Equal("abc", list[0].Name);
+            Assert.Equal(123, list[0].Id);
+            origReader.Dispose();
+
+            var secondReader = connection.ExecuteReader("select 'abc' as Name, 123 as Id");
+#pragma warning disable CS0618 // Type or member is obsolete
+            var secondParser = secondReader.GetRowParser(typeof(HazNameId));
+            var thirdParser = secondReader.GetRowParser(typeof(HazNameId), 1);
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            list = secondReader.Parse<HazNameId>().ToList();
+            Assert.Single(list);
+            Assert.Equal("abc", list[0].Name);
+            Assert.Equal(123, list[0].Id);
+            secondReader.Dispose();
+
+            // now: should be different readers, and because wrapped for IDataReader, not same parser
+            Assert.False(ReferenceEquals(origReader, secondReader));
+            Assert.False(ReferenceEquals(origParser, secondParser));
+            Assert.False(ReferenceEquals(secondParser, thirdParser));
+        }
+
+        [Fact]
+        public void GetSameReaderForSameShape_DbDataReader()
+        {
+            var origReader = Assert.IsAssignableFrom<DbDataReader>(connection.ExecuteReader("select 'abc' as Name, 123 as Id"));
             var origParser = origReader.GetRowParser(typeof(HazNameId));
 
             var typedParser = origReader.GetRowParser<HazNameId>();
@@ -29,7 +67,7 @@ namespace Dapper.Tests
             Assert.Equal(123, list[0].Id);
             origReader.Dispose();
 
-            var secondReader = connection.ExecuteReader("select 'abc' as Name, 123 as Id");
+            var secondReader = Assert.IsAssignableFrom<DbDataReader>(connection.ExecuteReader("select 'abc' as Name, 123 as Id"));
             var secondParser = secondReader.GetRowParser(typeof(HazNameId));
             var thirdParser = secondReader.GetRowParser(typeof(HazNameId), 1);
 
@@ -56,13 +94,54 @@ namespace Dapper.Tests
         }
 
         [Fact]
-        public void DiscriminatedUnion()
+        public void DiscriminatedUnion_IDataReader()
         {
             List<Discriminated_BaseType> result = new List<Discriminated_BaseType>();
             using (var reader = connection.ExecuteReader(@"
 select 'abc' as Name, 1 as Type, 3.0 as Value
 union all
 select 'def' as Name, 2 as Type, 4.0 as Value"))
+            {
+                if (reader.Read())
+                {
+#pragma warning disable CS0618
+                    var toFoo = reader.GetRowParser<Discriminated_BaseType>(typeof(Discriminated_Foo));
+                    var toBar = reader.GetRowParser<Discriminated_BaseType>(typeof(Discriminated_Bar));
+#pragma warning restore CS0618
+
+                    var col = reader.GetOrdinal("Type");
+                    do
+                    {
+                        switch (reader.GetInt32(col))
+                        {
+                            case 1:
+                                result.Add(toFoo(reader));
+                                break;
+                            case 2:
+                                result.Add(toBar(reader));
+                                break;
+                        }
+                    } while (reader.Read());
+                }
+            }
+
+            Assert.Equal(2, result.Count);
+            Assert.Equal(1, result[0].Type);
+            Assert.Equal(2, result[1].Type);
+            var foo = (Discriminated_Foo)result[0];
+            Assert.Equal("abc", foo.Name);
+            var bar = (Discriminated_Bar)result[1];
+            Assert.Equal(bar.Value, (float)4.0);
+        }
+
+        [Fact]
+        public void DiscriminatedUnion_DbDataReader()
+        {
+            List<Discriminated_BaseType> result = new List<Discriminated_BaseType>();
+            using (var reader = Assert.IsAssignableFrom<DbDataReader>(connection.ExecuteReader(@"
+select 'abc' as Name, 1 as Type, 3.0 as Value
+union all
+select 'def' as Name, 2 as Type, 4.0 as Value")))
             {
                 if (reader.Read())
                 {
@@ -95,13 +174,67 @@ select 'def' as Name, 2 as Type, 4.0 as Value"))
         }
 
         [Fact]
-        public void DiscriminatedUnionWithMultiMapping()
+        public void DiscriminatedUnionWithMultiMapping_IDataReader()
         {
             var result = new List<DiscriminatedWithMultiMapping_BaseType>();
             using (var reader = connection.ExecuteReader(@"
 select 'abc' as Name, 1 as Type, 3.0 as Value, 1 as Id, 'zxc' as Name
 union all
 select 'def' as Name, 2 as Type, 4.0 as Value, 2 as Id, 'qwe' as Name"))
+            {
+                if (reader.Read())
+                {
+                    var col = reader.GetOrdinal("Type");
+                    var splitOn = reader.GetOrdinal("Id");
+
+#pragma warning disable CS0618
+                    var toFoo = reader.GetRowParser<DiscriminatedWithMultiMapping_BaseType>(typeof(DiscriminatedWithMultiMapping_Foo), 0, splitOn);
+                    var toBar = reader.GetRowParser<DiscriminatedWithMultiMapping_BaseType>(typeof(DiscriminatedWithMultiMapping_Bar), 0, splitOn);
+                    var toHaz = reader.GetRowParser<HazNameId>(typeof(HazNameId), splitOn, reader.FieldCount - splitOn);
+#pragma warning restore CS0618
+
+                    do
+                    {
+                        DiscriminatedWithMultiMapping_BaseType obj = null;
+                        switch (reader.GetInt32(col))
+                        {
+                            case 1:
+                                obj = toFoo(reader);
+                                break;
+                            case 2:
+                                obj = toBar(reader);
+                                break;
+                        }
+
+                        Assert.NotNull(obj);
+                        obj.HazNameIdObject = toHaz(reader);
+                        result.Add(obj);
+
+                    } while (reader.Read());
+                }
+            }
+
+            Assert.Equal(2, result.Count);
+            Assert.Equal(1, result[0].Type);
+            Assert.Equal(2, result[1].Type);
+            var foo = (DiscriminatedWithMultiMapping_Foo)result[0];
+            Assert.Equal("abc", foo.Name);
+            Assert.Equal(1, foo.HazNameIdObject.Id);
+            Assert.Equal("zxc", foo.HazNameIdObject.Name);
+            var bar = (DiscriminatedWithMultiMapping_Bar)result[1];
+            Assert.Equal(bar.Value, (float)4.0);
+            Assert.Equal(2, bar.HazNameIdObject.Id);
+            Assert.Equal("qwe", bar.HazNameIdObject.Name);
+        }
+
+        [Fact]
+        public void DiscriminatedUnionWithMultiMapping_DbDataReader()
+        {
+            var result = new List<DiscriminatedWithMultiMapping_BaseType>();
+            using (var reader = Assert.IsAssignableFrom<DbDataReader>(connection.ExecuteReader(@"
+select 'abc' as Name, 1 as Type, 3.0 as Value, 1 as Id, 'zxc' as Name
+union all
+select 'def' as Name, 2 as Type, 4.0 as Value, 2 as Id, 'qwe' as Name")))
             {
                 if (reader.Read())
                 {


### PR DESCRIPTION
this requires `DbDataReader`, but in reality the reader is *always* `DbDataReader`; acknowledge this, and stop pretending to use `IDataReader` internally

The primary use for this is things like `SqlDecimal` which **cannot** be accessed other than via `DbDataReader.GetFieldValue<T>` or via `SqlDataReader.GetSqlDecimal`

fix #1907

the most relevant parts are:

- for things like `Query<SqlDecimal>`, the addition of `ReadViaGetFieldValueFactory` which is a per-T cached *factory* method that works a lot like the old logic (now enshrined in `ReadViaGetValue`), but using `IsDbNull` and `GetFieldValue<T>`
- the addition of `LoadReaderValueViaGetFieldValue`, which reads a value in IL via `IsDbNull` and `GetFieldValue<T>`; the use of `IsDbNull` means that we won't have anything to pop on the stack (unlike the old with did a read, dup, test, branch - leaving the original copy on the stack if we branched), which is tracked via `popWhenNull`