### PR TITLE
reinstate support for `IDataReader`

### DIFF
--- a/Dapper/SqlMapper.Async.cs
+++ b/Dapper/SqlMapper.Async.cs
@@ -1136,7 +1136,7 @@ namespace Dapper
                 var reader = await ExecuteReaderWithFlagsFallbackAsync(cmd, wasClosed, commandBehavior, command.CancellationToken).ConfigureAwait(false);
                 wasClosed = false;
                 disposeCommand = false;
-                return WrappedReader.Create(cmd, reader);
+                return DbWrappedReader.Create(cmd, reader);
             }
             finally
             {

--- a/Dapper/SqlMapper.IDataReader.cs
+++ b/Dapper/SqlMapper.IDataReader.cs
@@ -14,7 +14,7 @@ namespace Dapper
         /// <param name="reader">The data reader to parse results from.</param>
         public static IEnumerable<T> Parse<T>(this IDataReader reader)
         {
-            var dbReader = GetDbDataReader(reader, false);
+            var dbReader = GetDbDataReader(reader);
             if (dbReader.Read())
             {
                 var effectiveType = typeof(T);
@@ -42,7 +42,7 @@ namespace Dapper
         /// <param name="type">The type to parse from the <paramref name="reader"/>.</param>
         public static IEnumerable<object> Parse(this IDataReader reader, Type type)
         {
-            var dbReader = GetDbDataReader(reader, false);
+            var dbReader = GetDbDataReader(reader);
             if (dbReader.Read())
             {
                 var deser = GetDeserializer(type, dbReader, 0, -1, false);
@@ -59,7 +59,7 @@ namespace Dapper
         /// <param name="reader">The data reader to parse results from.</param>
         public static IEnumerable<dynamic> Parse(this IDataReader reader)
         {
-            var dbReader = GetDbDataReader(reader, false);
+            var dbReader = GetDbDataReader(reader);
             if (dbReader.Read())
             {
                 var deser = GetDapperRowDeserializer(dbReader, 0, -1, false);
@@ -86,7 +86,7 @@ namespace Dapper
         public static Func<IDataReader, object> GetRowParser(this IDataReader reader, Type type,
             int startIndex = 0, int length = -1, bool returnNullIfFirstMissing = false)
         {
-            return WrapObjectReader(GetDeserializer(type, GetDbDataReader(reader, false), startIndex, length, returnNullIfFirstMissing));
+            return WrapObjectReader(GetDeserializer(type, GetDbDataReader(reader), startIndex, length, returnNullIfFirstMissing));
         }
 
         /// <summary>
@@ -113,12 +113,12 @@ namespace Dapper
             int startIndex = 0, int length = -1, bool returnNullIfFirstMissing = false)
         {
             concreteType ??= typeof(T);
-            var func = GetDeserializer(concreteType, GetDbDataReader(reader, false), startIndex, length, returnNullIfFirstMissing);
+            var func = GetDeserializer(concreteType, GetDbDataReader(reader), startIndex, length, returnNullIfFirstMissing);
             return Wrap(func);
 
             // this is just to be very clear about what we're capturing
             static Func<IDataReader, T> Wrap(Func<DbDataReader, object> func)
-                => reader => (T)func(GetDbDataReader(reader, false));
+                => reader => (T)func(GetDbDataReader(reader));
         }
 
         /// <summary>

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,8 @@ Note: to get the latest pre-release build, add ` -Pre` to the end of the command
 
 ### unreleased
 
+- reinstate fallback support for `IDataReader`, and implement missing `DbDataReader` async APIs
+
 (note: new PRs will not be merged until they add release note wording here)
 
 ### 2.0.138

--- a/tests/Dapper.Tests/DataReaderTests.cs
+++ b/tests/Dapper.Tests/DataReaderTests.cs
@@ -96,7 +96,7 @@ namespace Dapper.Tests
         [Fact]
         public void DiscriminatedUnion_IDataReader()
         {
-            List<Discriminated_BaseType> result = new List<Discriminated_BaseType>();
+            var result = new List<Discriminated_BaseType>();
             using (var reader = connection.ExecuteReader(@"
 select 'abc' as Name, 1 as Type, 3.0 as Value
 union all
@@ -137,7 +137,7 @@ select 'def' as Name, 2 as Type, 4.0 as Value"))
         [Fact]
         public void DiscriminatedUnion_DbDataReader()
         {
-            List<Discriminated_BaseType> result = new List<Discriminated_BaseType>();
+            var result = new List<Discriminated_BaseType>();
             using (var reader = Assert.IsAssignableFrom<DbDataReader>(connection.ExecuteReader(@"
 select 'abc' as Name, 1 as Type, 3.0 as Value
 union all


### PR DESCRIPTION
in https://github.com/DapperLib/Dapper/commit/01f03ef3e860945d3c7a0caea443403ad85076ee, we focused everything around `DbDataReader`, but: if someone is currently using the sync API with a fake `IDbConnection` that returns `IDataReader`: it would have worked and we will have broken them

I'd rather not get the complaints; so here I reinstate support by *wrapping* `IDataReader` into our own `DbDataReader`; I will supplement this by adding an analyzer in AOT that yells at them until they change their ways

also:

- implement some missing async overrides in both of our `DbDataReader` implementations
- fixup compiler nits