### PR TITLE
Fix InvalidCastException when reading MySql DateTime

### DIFF
--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -3716,7 +3716,7 @@ namespace Dapper
                 {
                     TypeCode dataTypeCode = Type.GetTypeCode(colType), unboxTypeCode = Type.GetTypeCode(unboxType);
                     bool hasTypeHandler;
-                    if ((hasTypeHandler = typeHandlers.ContainsKey(unboxType)) || colType == unboxType || dataTypeCode == unboxTypeCode || dataTypeCode == Type.GetTypeCode(nullUnderlyingType))
+                    if ((hasTypeHandler = typeHandlers.ContainsKey(unboxType)) || colType == unboxType || dataTypeCode == (nullUnderlyingType != null ? Type.GetTypeCode(nullUnderlyingType) : unboxTypeCode))
                     {
                         if (hasTypeHandler)
                         {

--- a/tests/Dapper.Tests/Providers/MySQLTests.cs
+++ b/tests/Dapper.Tests/Providers/MySQLTests.cs
@@ -96,7 +96,7 @@ CREATE TEMPORARY TABLE IF NOT EXISTS `bar` (
             }
         }
 
-        [FactMySql(Skip = "See https://github.com/DapperLib/Dapper/issues/295, AllowZeroDateTime=True is not supported")]
+        [FactMySql]
         public void Issue295_NullableDateTime_MySql_AllowZeroDatetime()
         {
             using (var conn = Provider.GetMySqlConnection(true, false, true))
@@ -105,7 +105,7 @@ CREATE TEMPORARY TABLE IF NOT EXISTS `bar` (
             }
         }
 
-        [FactMySql(Skip = "See https://github.com/DapperLib/Dapper/issues/295, AllowZeroDateTime=True is not supported")]
+        [FactMySql]
         public void Issue295_NullableDateTime_MySql_ConvertAllowZeroDatetime()
         {
             using (var conn = Provider.GetMySqlConnection(true, true, true))


### PR DESCRIPTION
Before this commit, the following exception would be thrown:
> System.InvalidCastException
> Unable to cast object of type 'MySqlConnector.MySqlDateTime' to type 'System.Nullable`1[System.DateTime]'.
> at Deserialize74d21eca-a78e-49dc-b635-d007c613cb51(DbDataReader )

Fixes #295