### PR TITLE
Add missing non-generic QueryUnbufferedAsync API

### DIFF
--- a/Dapper/CommandDefinition.cs
+++ b/Dapper/CommandDefinition.cs
@@ -9,7 +9,7 @@ namespace Dapper
     /// <summary>
     /// Represents the key aspects of a sql operation
     /// </summary>
-    public struct CommandDefinition
+    public readonly struct CommandDefinition
     {
         internal static CommandDefinition ForCallback(object parameters)
         {

--- a/Dapper/SqlMapper.Async.cs
+++ b/Dapper/SqlMapper.Async.cs
@@ -530,7 +530,7 @@ namespace Dapper
             }
         }
 
-        private struct AsyncExecState
+        private readonly struct AsyncExecState
         {
             public readonly DbCommand Command;
             public readonly Task<int> Task;
@@ -1220,6 +1220,24 @@ namespace Dapper
         }
 
 #if NET5_0_OR_GREATER
+        /// <summary>
+        /// Execute a query asynchronously using <see cref="IAsyncEnumerable{dynamic}"/>.
+        /// </summary>
+        /// <param name="cnn">The connection to query on.</param>
+        /// <param name="sql">The SQL to execute for the query.</param>
+        /// <param name="param">The parameters to pass, if any.</param>
+        /// <param name="transaction">The transaction to use, if any.</param>
+        /// <param name="commandTimeout">The command timeout (in seconds).</param>
+        /// <param name="commandType">The type of command to execute.</param>
+        /// <returns>
+        /// A sequence of data of dynamic data
+        /// </returns>
+        public static IAsyncEnumerable<dynamic> QueryUnbufferedAsync(this DbConnection cnn, string sql, object param = null, DbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        {
+            // note: in many cases of adding a new async method I might add a CancellationToken - however, cancellation is expressed via WithCancellation on iterators
+            return QueryUnbufferedAsync<dynamic>(cnn, typeof(object), new CommandDefinition(sql, param, transaction, commandTimeout, commandType, CommandFlags.None, default));
+        }
+
         /// <summary>
         /// Execute a query asynchronously using <see cref="IAsyncEnumerable{T}"/>.
         /// </summary>

--- a/Dapper/SqlMapper.DeserializerState.cs
+++ b/Dapper/SqlMapper.DeserializerState.cs
@@ -6,7 +6,7 @@ namespace Dapper
 {
     public static partial class SqlMapper
     {
-        private struct DeserializerState
+        private readonly struct DeserializerState
         {
             public readonly int Hash;
             public readonly Func<DbDataReader, object> Func;

--- a/Dapper/SqlMapper.LiteralToken.cs
+++ b/Dapper/SqlMapper.LiteralToken.cs
@@ -8,7 +8,7 @@ namespace Dapper
         /// <summary>
         /// Represents a placeholder for a value that should be replaced as a literal value in the resulting sql
         /// </summary>
-        internal struct LiteralToken
+        internal readonly struct LiteralToken
         {
             /// <summary>
             /// The text in the original command that should be replaced

--- a/Dapper/SqlMapper.TypeDeserializerCache.cs
+++ b/Dapper/SqlMapper.TypeDeserializerCache.cs
@@ -1,9 +1,8 @@
 ﻿using System;
-using System.Data;
 using System.Collections;
 using System.Collections.Generic;
-using System.Text;
 using System.Data.Common;
+using System.Text;
 
 namespace Dapper
 {
@@ -16,7 +15,7 @@ namespace Dapper
                 this.type = type;
             }
 
-            private static readonly Hashtable byType = new Hashtable();
+            private static readonly Hashtable byType = new();
             private readonly Type type;
             internal static void Purge(Type type)
             {
@@ -51,9 +50,9 @@ namespace Dapper
                 return found.GetReader(reader, startBound, length, returnNullIfFirstMissing);
             }
 
-            private readonly Dictionary<DeserializerKey, Func<DbDataReader, object>> readers = new Dictionary<DeserializerKey, Func<DbDataReader, object>>();
+            private readonly Dictionary<DeserializerKey, Func<DbDataReader, object>> readers = new();
 
-            private struct DeserializerKey : IEquatable<DeserializerKey>
+            private readonly struct DeserializerKey : IEquatable<DeserializerKey>
             {
                 private readonly int startBound, length;
                 private readonly bool returnNullIfFirstMissing;

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,9 @@ Note: to get the latest pre-release build, add ` -Pre` to the end of the command
 
 ### unreleased
 
+- add missing non-generic `AsyncEnumerable<dynamic> QueryUnbufferedAsync(...)` API (#1925 via mgravell, fixes #1922)
+- formally mark all `struct` types as `readonly` (#1925 via mgravell)
+
 (note: new PRs will not be merged until they add release note wording here)
 
 ### 2.0.138

--- a/tests/Dapper.Tests/AsyncTests.cs
+++ b/tests/Dapper.Tests/AsyncTests.cs
@@ -48,6 +48,20 @@ namespace Dapper.Tests
 
 #if NET5_0_OR_GREATER
         [Fact]
+        public async Task TestBasicStringUsageUnbufferedDynamicAsync()
+        {
+            var results = new List<string>();
+            await foreach (var row in connection.QueryUnbufferedAsync("select 'abc' as [Value] union all select @txt", new { txt = "def" })
+                .ConfigureAwait(false))
+            {
+                string value = row.Value;
+                results.Add(value);
+            }
+            var arr = results.ToArray();
+            Assert.Equal(new[] { "abc", "def" }, arr);
+        }
+
+        [Fact]
         public async Task TestBasicStringUsageUnbufferedAsync()
         {
             var results = new List<string>();
@@ -192,7 +206,7 @@ namespace Dapper.Tests
         [Fact]
         public void TestLongOperationWithCancellation()
         {
-            CancellationTokenSource cancel = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            CancellationTokenSource cancel = new(TimeSpan.FromSeconds(5));
             var task = connection.QueryAsync<int>(new CommandDefinition("waitfor delay '00:00:10';select 1", cancellationToken: cancel.Token));
             try
             {


### PR DESCRIPTION
also mark all `struct` types as `readonly`

fix #1922 