### PR TITLE
Allow configuration of empty parameter list SQL

### DIFF
--- a/Dapper/SqlMapper.Settings.cs
+++ b/Dapper/SqlMapper.Settings.cs
@@ -64,6 +64,7 @@ namespace Dapper
             {
                 CommandTimeout = null;
                 ApplyNullValues = false;
+                EmptyParameterListFormat = "(select null where 1=0)";
             }
 
             /// <summary>
@@ -99,6 +100,11 @@ namespace Dapper
             /// instead of the original name; for most scenarios, this is ignored since the name is redundant, but "snowflake" requires this.
             /// </summary>
             public static bool UseIncrementalPseudoPositionalParameterNames { get; set; }
+
+            /// <summary>
+            /// The SQL used when a list parameter is empty.
+            /// </summary>
+            public static string EmptyParameterListFormat { get; set; }
         }
     }
 }

--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -2437,7 +2437,7 @@ namespace Dapper
                             }
                             if (first)
                             {
-                                return "(select null where 1=0)";
+                                return Settings.EmptyParameterListFormat;
                             }
                             else
                             {


### PR DESCRIPTION
Dapper is currently hardcoded to embed `(select null where 1=0)` when it detects empty list parameters. While it works for most db servers, some times that sql is invalid or sub-optimal. This change allows it to be configured by the library consumer.

This issue was discussed in #565 and I could not find a pull request which addressed it.

Thanks