### PR TITLE
Fix issue 222: MultiMap does not return null object

### DIFF
--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -3547,6 +3547,26 @@ namespace Dapper
 
                     il.MarkLabel(finishLabel);
                 }
+                else
+                {
+                    if (first && returnNullIfFirstMissing)
+                    {
+                        Label finishLabel = il.DefineLabel();
+
+                        il.Emit(OpCodes.Ldarg_0); // stack is now [target][reader]
+                        EmitInt32(il, index); // stack is now [target][reader][index]
+                        il.Emit(OpCodes.Callvirt, isDbNull); // stack is now [target][bool]
+                        il.Emit(OpCodes.Brfalse_S, finishLabel);
+
+                        il.Emit(OpCodes.Pop);
+                        il.Emit(OpCodes.Ldnull); // stack is now [null]
+                        il.Emit(OpCodes.Stloc, returnValueLocal);
+                        il.Emit(OpCodes.Br, allDone);
+
+                        il.MarkLabel(finishLabel); // stack is now [target]
+                    }
+                }
+
                 first = false;
                 index++;
             }

--- a/tests/Dapper.Tests/MultiMapTests.cs
+++ b/tests/Dapper.Tests/MultiMapTests.cs
@@ -268,7 +268,7 @@ Order by p.Id";
         }
 
         [Fact]
-        public void TestMultiMapWithSplitWithNullValueAndSpoofColumn() // https://stackoverflow.com/q/10744728/449906
+        public void TestMultiMapWithSplitWithNotNullValueInSpoofColumn() // https://stackoverflow.com/q/10744728/449906
         {
             const string sql = "select 1 as id, 'abc' as name, 1 as spoof, NULL as description, 'def' as name";
             var product = connection.Query<Product, Category, Product>(sql, (prod, cat) =>
@@ -283,6 +283,21 @@ Order by p.Id";
             Assert.Equal(0, product.Category.Id);
             Assert.Equal("def", product.Category.Name);
             Assert.Null(product.Category.Description);
+        }
+
+        [Fact]
+        public void TestMultiMapWithSplitWithNullValueInSpoofColumn()
+        {
+            const string sql = "select 1 as id, 'abc' as name, NULL as spoof, NULL as description, 'def' as name";
+            var product = connection.Query<Product, Category, Product>(sql, (prod, cat) =>
+            {
+                prod.Category = cat;
+                return prod;
+            }, splitOn: "spoof").First();
+            // assertions
+            Assert.Equal(1, product.Id);
+            Assert.Equal("abc", product.Name);
+            Assert.Null(product.Category);
         }
 
         [Fact]


### PR DESCRIPTION
Fix issue https://github.com/DapperLib/Dapper/issues/222: MultiMap does not return null object in left-outer-join if splitting on a surrogate key that is not a property on the target object.