### PR TITLE
Removed block nesting levels in a few tests by using block-scoped `using` statements

### DIFF
--- a/tests/Dapper.Tests/AsyncTests.cs
+++ b/tests/Dapper.Tests/AsyncTests.cs
@@ -224,12 +224,10 @@ namespace Dapper.Tests
         [Fact]
         public async Task TestBasicStringUsageClosedAsync()
         {
-            using (var conn = GetClosedConnection())
-            {
-                var query = await conn.QueryAsync<string>("select 'abc' as [Value] union all select @txt", new { txt = "def" }).ConfigureAwait(false);
-                var arr = query.ToArray();
-                Assert.Equal(new[] { "abc", "def" }, arr);
-            }
+            using var conn = GetClosedConnection();
+            var query = await conn.QueryAsync<string>("select 'abc' as [Value] union all select @txt", new { txt = "def" }).ConfigureAwait(false);
+            var arr = query.ToArray();
+            Assert.Equal(new[] { "abc", "def" }, arr);
         }
 
         [Fact]
@@ -258,12 +256,10 @@ namespace Dapper.Tests
         [Fact]
         public void TestExecuteClosedConnAsyncInner()
         {
-            using (var conn = GetClosedConnection())
-            {
-                var query = conn.ExecuteAsync("declare @foo table(id int not null); insert @foo values(@id);", new { id = 1 });
-                var val = query.Result;
-                Assert.Equal(1, val);
-            }
+            using var conn = GetClosedConnection();
+            var query = conn.ExecuteAsync("declare @foo table(id int not null); insert @foo values(@id);", new { id = 1 });
+            var val = query.Result;
+            Assert.Equal(1, val);
         }
 
         [Fact]
@@ -307,83 +303,69 @@ namespace Dapper.Tests
         public async Task TestMultiMapWithSplitClosedConnAsync()
         {
             const string sql = "select 1 as id, 'abc' as name, 2 as id, 'def' as name";
-            using (var conn = GetClosedConnection())
-            {
-                var productQuery = await conn.QueryAsync<Product, Category, Product>(sql, (prod, cat) =>
-                {
-                    prod.Category = cat;
-                    return prod;
-                }).ConfigureAwait(false);
 
-                var product = productQuery.First();
-                // assertions
-                Assert.Equal(1, product.Id);
-                Assert.Equal("abc", product.Name);
-                Assert.Equal(2, product.Category.Id);
-                Assert.Equal("def", product.Category.Name);
-            }
+            using var conn = GetClosedConnection();
+
+            var productQuery = await conn.QueryAsync<Product, Category, Product>(sql, (prod, cat) =>
+            {
+                prod.Category = cat;
+                return prod;
+            }).ConfigureAwait(false);
+
+            var product = productQuery.First();
+            // assertions
+            Assert.Equal(1, product.Id);
+            Assert.Equal("abc", product.Name);
+            Assert.Equal(2, product.Category.Id);
+            Assert.Equal("def", product.Category.Name);
         }
 
         [Fact]
         public async Task TestMultiAsync()
         {
-            using (SqlMapper.GridReader multi = await connection.QueryMultipleAsync("select 1; select 2").ConfigureAwait(false))
-            {
-                Assert.Equal(1, multi.ReadAsync<int>().Result.Single());
-                Assert.Equal(2, multi.ReadAsync<int>().Result.Single());
-            }
+            using SqlMapper.GridReader multi = await connection.QueryMultipleAsync("select 1; select 2").ConfigureAwait(false);
+            Assert.Equal(1, multi.ReadAsync<int>().Result.Single());
+            Assert.Equal(2, multi.ReadAsync<int>().Result.Single());
         }
 
         [Fact]
         public async Task TestMultiConversionAsync()
         {
-            using (SqlMapper.GridReader multi = await connection.QueryMultipleAsync("select Cast(1 as BigInt) Col1; select Cast(2 as BigInt) Col2").ConfigureAwait(false))
-            {
-                Assert.Equal(1, multi.ReadAsync<int>().Result.Single());
-                Assert.Equal(2, multi.ReadAsync<int>().Result.Single());
-            }
+            using SqlMapper.GridReader multi = await connection.QueryMultipleAsync("select Cast(1 as BigInt) Col1; select Cast(2 as BigInt) Col2").ConfigureAwait(false);
+            Assert.Equal(1, multi.ReadAsync<int>().Result.Single());
+            Assert.Equal(2, multi.ReadAsync<int>().Result.Single());
         }
 
         [Fact]
         public async Task TestMultiAsyncViaFirstOrDefault()
         {
-            using (SqlMapper.GridReader multi = await connection.QueryMultipleAsync("select 1; select 2; select 3; select 4; select 5").ConfigureAwait(false))
-            {
-                Assert.Equal(1, multi.ReadFirstOrDefaultAsync<int>().Result);
-                Assert.Equal(2, multi.ReadAsync<int>().Result.Single());
-                Assert.Equal(3, multi.ReadFirstOrDefaultAsync<int>().Result);
-                Assert.Equal(4, multi.ReadAsync<int>().Result.Single());
-                Assert.Equal(5, multi.ReadFirstOrDefaultAsync<int>().Result);
-            }
+            using SqlMapper.GridReader multi = await connection.QueryMultipleAsync("select 1; select 2; select 3; select 4; select 5").ConfigureAwait(false);
+            Assert.Equal(1, multi.ReadFirstOrDefaultAsync<int>().Result);
+            Assert.Equal(2, multi.ReadAsync<int>().Result.Single());
+            Assert.Equal(3, multi.ReadFirstOrDefaultAsync<int>().Result);
+            Assert.Equal(4, multi.ReadAsync<int>().Result.Single());
+            Assert.Equal(5, multi.ReadFirstOrDefaultAsync<int>().Result);
         }
 
         [Fact]
         public async Task TestMultiClosedConnAsync()
         {
-            using (var conn = GetClosedConnection())
-            {
-                using (SqlMapper.GridReader multi = await conn.QueryMultipleAsync("select 1; select 2").ConfigureAwait(false))
-                {
-                    Assert.Equal(1, multi.ReadAsync<int>().Result.Single());
-                    Assert.Equal(2, multi.ReadAsync<int>().Result.Single());
-                }
-            }
+            using var conn = GetClosedConnection();
+            using SqlMapper.GridReader multi = await conn.QueryMultipleAsync("select 1; select 2").ConfigureAwait(false);
+            Assert.Equal(1, multi.ReadAsync<int>().Result.Single());
+            Assert.Equal(2, multi.ReadAsync<int>().Result.Single());
         }
 
         [Fact]
         public async Task TestMultiClosedConnAsyncViaFirstOrDefault()
         {
-            using (var conn = GetClosedConnection())
-            {
-                using (SqlMapper.GridReader multi = await conn.QueryMultipleAsync("select 1; select 2; select 3; select 4; select 5").ConfigureAwait(false))
-                {
-                    Assert.Equal(1, multi.ReadFirstOrDefaultAsync<int>().Result);
-                    Assert.Equal(2, multi.ReadAsync<int>().Result.Single());
-                    Assert.Equal(3, multi.ReadFirstOrDefaultAsync<int>().Result);
-                    Assert.Equal(4, multi.ReadAsync<int>().Result.Single());
-                    Assert.Equal(5, multi.ReadFirstOrDefaultAsync<int>().Result);
-                }
-            }
+            using var conn = GetClosedConnection();
+            using SqlMapper.GridReader multi = await conn.QueryMultipleAsync("select 1; select 2; select 3; select 4; select 5").ConfigureAwait(false);
+            Assert.Equal(1, multi.ReadFirstOrDefaultAsync<int>().Result);
+            Assert.Equal(2, multi.ReadAsync<int>().Result.Single());
+            Assert.Equal(3, multi.ReadFirstOrDefaultAsync<int>().Result);
+            Assert.Equal(4, multi.ReadAsync<int>().Result.Single());
+            Assert.Equal(5, multi.ReadFirstOrDefaultAsync<int>().Result);
         }
 
         [Fact]
@@ -402,17 +384,15 @@ namespace Dapper.Tests
         [Fact]
         public async Task ExecuteReaderClosedAsync()
         {
-            using (var conn = GetClosedConnection())
-            {
-                var dt = new DataTable();
-                dt.Load(await conn.ExecuteReaderAsync("select 3 as [three], 4 as [four]").ConfigureAwait(false));
-                Assert.Equal(2, dt.Columns.Count);
-                Assert.Equal("three", dt.Columns[0].ColumnName);
-                Assert.Equal("four", dt.Columns[1].ColumnName);
-                Assert.Equal(1, dt.Rows.Count);
-                Assert.Equal(3, (int)dt.Rows[0][0]);
-                Assert.Equal(4, (int)dt.Rows[0][1]);
-            }
+            using var conn = GetClosedConnection();
+            var dt = new DataTable();
+            dt.Load(await conn.ExecuteReaderAsync("select 3 as [three], 4 as [four]").ConfigureAwait(false));
+            Assert.Equal(2, dt.Columns.Count);
+            Assert.Equal("three", dt.Columns[0].ColumnName);
+            Assert.Equal("four", dt.Columns[1].ColumnName);
+            Assert.Equal(1, dt.Rows.Count);
+            Assert.Equal(3, (int)dt.Rows[0][0]);
+            Assert.Equal(4, (int)dt.Rows[0][1]);
         }
 
         [Fact]
@@ -424,7 +404,8 @@ namespace Dapper.Tests
         [Fact]
         public async Task LiteralReplacementClosed()
         {
-            using (var conn = GetClosedConnection()) await LiteralReplacement(conn).ConfigureAwait(false);
+            using var conn = GetClosedConnection();
+            await LiteralReplacement(conn).ConfigureAwait(false);
         }
 
         private static async Task LiteralReplacement(IDbConnection conn)
@@ -453,7 +434,8 @@ namespace Dapper.Tests
         [Fact]
         public async Task LiteralReplacementDynamicClosed()
         {
-            using (var conn = GetClosedConnection()) await LiteralReplacementDynamic(conn).ConfigureAwait(false);
+            using var conn = GetClosedConnection();
+            await LiteralReplacementDynamic(conn).ConfigureAwait(false);
         }
 
         private static async Task LiteralReplacementDynamic(IDbConnection conn)
@@ -917,14 +899,12 @@ SET @AddressPersonId = @PersonId", p).ConfigureAwait(false))
         [Fact]
         public async Task Issue1281_DataReaderOutOfOrderAsync()
         {
-            using (var reader = await connection.ExecuteReaderAsync("Select 0, 1, 2").ConfigureAwait(false))
-            {
-                Assert.True(reader.Read());
-                Assert.Equal(2, reader.GetInt32(2));
-                Assert.Equal(0, reader.GetInt32(0));
-                Assert.Equal(1, reader.GetInt32(1));
-                Assert.False(reader.Read());
-            }
+            using var reader = await connection.ExecuteReaderAsync("Select 0, 1, 2").ConfigureAwait(false);
+            Assert.True(reader.Read());
+            Assert.Equal(2, reader.GetInt32(2));
+            Assert.Equal(0, reader.GetInt32(0));
+            Assert.Equal(1, reader.GetInt32(1));
+            Assert.False(reader.Read());
         }
 
         [Fact]

--- a/tests/Dapper.Tests/DecimalTests.cs
+++ b/tests/Dapper.Tests/DecimalTests.cs
@@ -34,11 +34,9 @@ namespace Dapper.Tests
         {
             try
             {
-                using (var cmd = connection.CreateCommand())
-                {
-                    cmd.CommandText = "create proc #Issue261Direct @c decimal(10,5) OUTPUT as begin set @c=11.884 end";
-                    cmd.ExecuteNonQuery();
-                }
+                using var cmd = connection.CreateCommand();
+                cmd.CommandText = "create proc #Issue261Direct @c decimal(10,5) OUTPUT as begin set @c=11.884 end";
+                cmd.ExecuteNonQuery();
             }
             catch { /* we don't care that it already exists */ }
 

--- a/tests/Dapper.Tests/EnumTests.cs
+++ b/tests/Dapper.Tests/EnumTests.cs
@@ -92,18 +92,16 @@ namespace Dapper.Tests
         [Fact]
         public void AdoNetEnumValue()
         {
-            using (var cmd = connection.CreateCommand())
-            {
-                cmd.CommandText = "select @foo";
-                var p = cmd.CreateParameter();
-                p.ParameterName = "@foo";
-                p.DbType = DbType.Int32; // it turns out that this is the key piece; setting the DbType
-                p.Value = AnEnum.B;
-                cmd.Parameters.Add(p);
-                object value = cmd.ExecuteScalar();
-                AnEnum val = (AnEnum)value;
-                Assert.Equal(AnEnum.B, val);
-            }
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "select @foo";
+            var p = cmd.CreateParameter();
+            p.ParameterName = "@foo";
+            p.DbType = DbType.Int32; // it turns out that this is the key piece; setting the DbType
+            p.Value = AnEnum.B;
+            cmd.Parameters.Add(p);
+            object value = cmd.ExecuteScalar();
+            AnEnum val = (AnEnum)value;
+            Assert.Equal(AnEnum.B, val);
         }
 
         [Fact]

--- a/tests/Dapper.Tests/Helpers/Attributes.cs
+++ b/tests/Dapper.Tests/Helpers/Attributes.cs
@@ -59,14 +59,12 @@ namespace Dapper.Tests
         public static readonly int DetectedLevel;
         static FactRequiredCompatibilityLevelAttribute()
         {
-            using (var conn = DatabaseProvider<SystemSqlClientProvider>.Instance.GetOpenConnection())
+            using var conn = DatabaseProvider<SystemSqlClientProvider>.Instance.GetOpenConnection();
+            try
             {
-                try
-                {
-                    DetectedLevel = conn.QuerySingle<int>("SELECT compatibility_level FROM sys.databases where name = DB_NAME()");
-                }
-                catch { /* don't care */ }
+                DetectedLevel = conn.QuerySingle<int>("SELECT compatibility_level FROM sys.databases where name = DB_NAME()");
             }
+            catch { /* don't care */ }
         }
     }
 
@@ -84,20 +82,18 @@ namespace Dapper.Tests
         public static readonly bool IsCaseSensitive;
         static FactUnlessCaseSensitiveDatabaseAttribute()
         {
-            using (var conn = DatabaseProvider<SystemSqlClientProvider>.Instance.GetOpenConnection())
+            using var conn = DatabaseProvider<SystemSqlClientProvider>.Instance.GetOpenConnection();
+            try
             {
-                try
-                {
-                    conn.Execute("declare @i int; set @I = 1;");
-                }
-                catch (Exception ex) when (ex.GetType().Name == "SqlException")
-                {
-                    int err = ((dynamic)ex).Number;
-                    if (err == 137)
-                        IsCaseSensitive = true;
-                    else
-                        throw;
-                }
+                conn.Execute("declare @i int; set @I = 1;");
+            }
+            catch (Exception ex) when (ex.GetType().Name == "SqlException")
+            {
+                int err = ((dynamic)ex).Number;
+                if (err == 137)
+                    IsCaseSensitive = true;
+                else
+                    throw;
             }
         }
     }

--- a/tests/Dapper.Tests/MiscTests.cs
+++ b/tests/Dapper.Tests/MiscTests.cs
@@ -909,42 +909,34 @@ select * from @bar", new { foo }).Single();
         [Fact]
         public void ExecuteFromClosed()
         {
-            using (var conn = GetClosedConnection())
-            {
-                conn.Execute("-- nop");
-                Assert.Equal(ConnectionState.Closed, conn.State);
-            }
+            using var conn = GetClosedConnection();
+            conn.Execute("-- nop");
+            Assert.Equal(ConnectionState.Closed, conn.State);
         }
 
         [Fact]
         public void ExecuteInvalidFromClosed()
         {
-            using (var conn = GetClosedConnection())
-            {
-                var ex = Assert.ThrowsAny<Exception>(() => conn.Execute("nop"));
-                Assert.Equal(ConnectionState.Closed, conn.State);
-            }
+            using var conn = GetClosedConnection();
+            var ex = Assert.ThrowsAny<Exception>(() => conn.Execute("nop"));
+            Assert.Equal(ConnectionState.Closed, conn.State);
         }
 
         [Fact]
         public void QueryFromClosed()
         {
-            using (var conn = GetClosedConnection())
-            {
-                var i = conn.Query<int>("select 1").Single();
-                Assert.Equal(ConnectionState.Closed, conn.State);
-                Assert.Equal(1, i);
-            }
+            using var conn = GetClosedConnection();
+            var i = conn.Query<int>("select 1").Single();
+            Assert.Equal(ConnectionState.Closed, conn.State);
+            Assert.Equal(1, i);
         }
 
         [Fact]
         public void QueryInvalidFromClosed()
         {
-            using (var conn = GetClosedConnection())
-            {
-                Assert.ThrowsAny<Exception>(() => conn.Query<int>("select gibberish").Single());
-                Assert.Equal(ConnectionState.Closed, conn.State);
-            }
+            using var conn = GetClosedConnection();
+            Assert.ThrowsAny<Exception>(() => conn.Query<int>("select gibberish").Single());
+            Assert.Equal(ConnectionState.Closed, conn.State);
         }
 
         [Fact]
@@ -1148,13 +1140,11 @@ select * from @bar", new { foo }).Single();
             using (var sqlCmd = connection.CreateCommand())
             {
                 sqlCmd.CommandText = sql;
-                using (IDataReader reader1 = sqlCmd.ExecuteReader())
-                {
-                    Assert.True(reader1.Read());
-                    Assert.Equal(0, reader1.GetInt32(0));
-                    Assert.False(reader1.Read());
-                    Assert.False(reader1.NextResult());
-                }
+                using IDataReader reader1 = sqlCmd.ExecuteReader();
+                Assert.True(reader1.Read());
+                Assert.Equal(0, reader1.GetInt32(0));
+                Assert.False(reader1.Read());
+                Assert.False(reader1.NextResult());
             }
 
             // dapper

--- a/tests/Dapper.Tests/MultiMapTests.cs
+++ b/tests/Dapper.Tests/MultiMapTests.cs
@@ -132,13 +132,11 @@ Order by p.Id";
         [Fact]
         public void QueryMultimapFromClosed()
         {
-            using (var conn = GetClosedConnection())
-            {
-                Assert.Equal(ConnectionState.Closed, conn.State);
-                var i = conn.Query<Multi1, Multi2, int>("select 2 as [Id], 3 as [Id]", (x, y) => x.Id + y.Id).Single();
-                Assert.Equal(ConnectionState.Closed, conn.State);
-                Assert.Equal(5, i);
-            }
+            using var conn = GetClosedConnection();
+            Assert.Equal(ConnectionState.Closed, conn.State);
+            var i = conn.Query<Multi1, Multi2, int>("select 2 as [Id], 3 as [Id]", (x, y) => x.Id + y.Id).Single();
+            Assert.Equal(ConnectionState.Closed, conn.State);
+            Assert.Equal(5, i);
         }
 
         [Fact]

--- a/tests/Dapper.Tests/ProviderTests.cs
+++ b/tests/Dapper.Tests/ProviderTests.cs
@@ -10,19 +10,15 @@ namespace Dapper.Tests
         [Fact]
         public void BulkCopy_SystemDataSqlClient()
         {
-            using (var conn = new System.Data.SqlClient.SqlConnection())
-            {
-                Test<System.Data.SqlClient.SqlBulkCopy>(conn);
-            }
+            using var conn = new System.Data.SqlClient.SqlConnection();
+            Test<System.Data.SqlClient.SqlBulkCopy>(conn);
         }
 
         [Fact]
         public void BulkCopy_MicrosoftDataSqlClient()
         {
-            using (var conn = new Microsoft.Data.SqlClient.SqlConnection())
-            {
-                Test<Microsoft.Data.SqlClient.SqlBulkCopy>(conn);
-            }
+            using var conn = new Microsoft.Data.SqlClient.SqlConnection();
+            Test<Microsoft.Data.SqlClient.SqlBulkCopy>(conn);
         }
 
         [Fact]
@@ -55,41 +51,33 @@ namespace Dapper.Tests
              where T : SqlServerDatabaseProvider, new()
         {
             var provider = new T();
-            using (var conn = provider.GetOpenConnection())
-            {
-                Assert.True(conn.TryGetClientConnectionId(out var id));
-                Assert.NotEqual(Guid.Empty, id);
-            }
+            using var conn = provider.GetOpenConnection();
+            Assert.True(conn.TryGetClientConnectionId(out var id));
+            Assert.NotEqual(Guid.Empty, id);
         }
 
         private static void ClearPool<T>()
      where T : SqlServerDatabaseProvider, new()
         {
             var provider = new T();
-            using (var conn = provider.GetOpenConnection())
-            {
-                Assert.True(conn.TryClearPool());
-            }
+            using var conn = provider.GetOpenConnection();
+            Assert.True(conn.TryClearPool());
         }
 
         private static void ClearAllPools<T>()
      where T : SqlServerDatabaseProvider, new()
         {
             var provider = new T();
-            using (var conn = provider.GetOpenConnection())
-            {
-                Assert.True(conn.TryClearAllPools());
-            }
+            using var conn = provider.GetOpenConnection();
+            Assert.True(conn.TryClearAllPools());
         }
 
         private static void Test<T>(DbConnection connection)
         {
-            using (var bcp = BulkCopy.TryCreate(connection))
-            {
-                Assert.NotNull(bcp);
-                Assert.IsType<T>(bcp.Wrapped);
-                bcp.EnableStreaming = true;
-            }
+            using var bcp = BulkCopy.TryCreate(connection);
+            Assert.NotNull(bcp);
+            Assert.IsType<T>(bcp.Wrapped);
+            bcp.EnableStreaming = true;
         }
 
         [Theory]
@@ -110,17 +98,17 @@ namespace Dapper.Tests
             where T : SqlServerDatabaseProvider, new()
         {
             var provider = new T();
-            using (var conn = provider.GetOpenConnection())
+            
+            using var conn = provider.GetOpenConnection();
+
+            try
             {
-                try
-                {
-                    conn.Execute("throw @create, 'boom', 1;", new { create });
-                    Assert.False(true);
-                }
-                catch(DbException err)
-                {
-                    Assert.Equal(result, err.IsNumber(test));
-                }
+                conn.Execute("throw @create, 'boom', 1;", new { create });
+                Assert.False(true);
+            }
+            catch(DbException err)
+            {
+                Assert.Equal(result, err.IsNumber(test));
             }
         }
     }

--- a/tests/Dapper.Tests/Providers/FirebirdTests.cs
+++ b/tests/Dapper.Tests/Providers/FirebirdTests.cs
@@ -24,35 +24,34 @@ namespace Dapper.Tests.Providers
         [Fact(Skip = "Bug in Firebird; a PR to fix it has been submitted")]
         public void Issue178_Firebird()
         {
-            using (var connection = GetOpenFirebirdConnection())
+            using var connection = GetOpenFirebirdConnection();
+
+            const string sql = "select count(*) from Issue178";
+            try { connection.Execute("drop table Issue178"); }
+            catch { /* don't care */ }
+            connection.Execute("create table Issue178(id int not null)");
+            connection.Execute("insert into Issue178(id) values(42)");
+            // raw ADO.net
+            using (var sqlCmd = new FbCommand(sql, connection))
+            using (IDataReader reader1 = sqlCmd.ExecuteReader())
             {
-                const string sql = "select count(*) from Issue178";
-                try { connection.Execute("drop table Issue178"); }
-                catch { /* don't care */ }
-                connection.Execute("create table Issue178(id int not null)");
-                connection.Execute("insert into Issue178(id) values(42)");
-                // raw ADO.net
-                using (var sqlCmd = new FbCommand(sql, connection))
-                using (IDataReader reader1 = sqlCmd.ExecuteReader())
-                {
-                    Assert.True(reader1.Read());
-                    Assert.Equal(1, reader1.GetInt32(0));
-                    Assert.False(reader1.Read());
-                    Assert.False(reader1.NextResult());
-                }
-
-                // dapper
-                using (var reader2 = connection.ExecuteReader(sql))
-                {
-                    Assert.True(reader2.Read());
-                    Assert.Equal(1, reader2.GetInt32(0));
-                    Assert.False(reader2.Read());
-                    Assert.False(reader2.NextResult());
-                }
-
-                var count = connection.Query<int>(sql).Single();
-                Assert.Equal(1, count);
+                Assert.True(reader1.Read());
+                Assert.Equal(1, reader1.GetInt32(0));
+                Assert.False(reader1.Read());
+                Assert.False(reader1.NextResult());
             }
+
+            // dapper
+            using (var reader2 = connection.ExecuteReader(sql))
+            {
+                Assert.True(reader2.Read());
+                Assert.Equal(1, reader2.GetInt32(0));
+                Assert.False(reader2.Read());
+                Assert.False(reader2.NextResult());
+            }
+
+            var count = connection.Query<int>(sql).Single();
+            Assert.Equal(1, count);
         }
     }
 }

--- a/tests/Dapper.Tests/Providers/MySQLTests.cs
+++ b/tests/Dapper.Tests/Providers/MySQLTests.cs
@@ -38,10 +38,8 @@ namespace Dapper.Tests
         [FactMySql]
         public void DapperEnumValue_Mysql()
         {
-            using (var conn = Provider.GetMySqlConnection())
-            {
-                Common.DapperEnumValue(conn);
-            }
+            using var conn = Provider.GetMySqlConnection();
+            Common.DapperEnumValue(conn);
         }
 
         [FactMySql]
@@ -87,19 +85,15 @@ CREATE TEMPORARY TABLE IF NOT EXISTS `bar` (
         [FactMySql]
         public void Issue295_NullableDateTime_MySql_Default()
         {
-            using (var conn = Provider.GetMySqlConnection(true, false, false))
-            {
-                Common.TestDateTime(conn);
-            }
+            using var conn = Provider.GetMySqlConnection(true, false, false);
+            Common.TestDateTime(conn);
         }
 
         [FactMySql]
         public void Issue295_NullableDateTime_MySql_ConvertZeroDatetime()
         {
-            using (var conn = Provider.GetMySqlConnection(true, true, false))
-            {
-                Common.TestDateTime(conn);
-            }
+            using var conn = Provider.GetMySqlConnection(true, true, false);
+            Common.TestDateTime(conn);
         }
 
         [FactMySql(Skip = "See https://github.com/DapperLib/Dapper/issues/295, AllowZeroDateTime=True is not supported")]
@@ -114,97 +108,91 @@ CREATE TEMPORARY TABLE IF NOT EXISTS `bar` (
         [FactMySql(Skip = "See https://github.com/DapperLib/Dapper/issues/295, AllowZeroDateTime=True is not supported")]
         public void Issue295_NullableDateTime_MySql_ConvertAllowZeroDatetime()
         {
-            using (var conn = Provider.GetMySqlConnection(true, true, true))
-            {
-                Common.TestDateTime(conn);
-            }
+            using var conn = Provider.GetMySqlConnection(true, true, true);
+            Common.TestDateTime(conn);
         }
 
         [FactMySql]
         public void Issue426_SO34439033_DateTimeGainsTicks()
         {
-            using (var conn = Provider.GetMySqlConnection(true, true, true))
+            using var conn = Provider.GetMySqlConnection(true, true, true);
+
+            try { conn.Execute("drop table Issue426_Test"); } catch { /* don't care */ }
+            try { conn.Execute("create table Issue426_Test (Id int not null, Time time not null)"); } catch { /* don't care */ }
+            const long ticks = 553440000000;
+            const int Id = 426;
+
+            var localObj = new Issue426_Test
             {
-                try { conn.Execute("drop table Issue426_Test"); } catch { /* don't care */ }
-                try { conn.Execute("create table Issue426_Test (Id int not null, Time time not null)"); } catch { /* don't care */ }
-                const long ticks = 553440000000;
-                const int Id = 426;
+                Id = Id,
+                Time = TimeSpan.FromTicks(ticks) // from code example
+            };
+            conn.Execute("replace into Issue426_Test values (@Id,@Time)", localObj);
 
-                var localObj = new Issue426_Test
-                {
-                    Id = Id,
-                    Time = TimeSpan.FromTicks(ticks) // from code example
-                };
-                conn.Execute("replace into Issue426_Test values (@Id,@Time)", localObj);
-
-                var dbObj = conn.Query<Issue426_Test>("select * from Issue426_Test where Id = @id", new { id = Id }).Single();
-                Assert.Equal(Id, dbObj.Id);
-                Assert.Equal(ticks, dbObj.Time.Value.Ticks);
-            }
+            var dbObj = conn.Query<Issue426_Test>("select * from Issue426_Test where Id = @id", new { id = Id }).Single();
+            Assert.Equal(Id, dbObj.Id);
+            Assert.Equal(ticks, dbObj.Time.Value.Ticks);
         }
 
         [FactMySql]
         public void SO36303462_Tinyint_Bools()
         {
-            using (var conn = Provider.GetMySqlConnection(true, true, true))
-            {
-                try { conn.Execute("drop table SO36303462_Test"); } catch { /* don't care */ }
-                conn.Execute("create table SO36303462_Test (Id int not null, IsBold tinyint not null);");
-                conn.Execute("insert SO36303462_Test (Id, IsBold) values (1,1);");
-                conn.Execute("insert SO36303462_Test (Id, IsBold) values (2,0);");
-                conn.Execute("insert SO36303462_Test (Id, IsBold) values (3,1);");
+            using var conn = Provider.GetMySqlConnection(true, true, true);
 
-                var rows = conn.Query<SO36303462>("select * from SO36303462_Test").ToDictionary(x => x.Id);
-                Assert.Equal(3, rows.Count);
-                Assert.True(rows[1].IsBold);
-                Assert.False(rows[2].IsBold);
-                Assert.True(rows[3].IsBold);
-            }
+            try { conn.Execute("drop table SO36303462_Test"); } catch { /* don't care */ }
+            conn.Execute("create table SO36303462_Test (Id int not null, IsBold tinyint not null);");
+            conn.Execute("insert SO36303462_Test (Id, IsBold) values (1,1);");
+            conn.Execute("insert SO36303462_Test (Id, IsBold) values (2,0);");
+            conn.Execute("insert SO36303462_Test (Id, IsBold) values (3,1);");
+
+            var rows = conn.Query<SO36303462>("select * from SO36303462_Test").ToDictionary(x => x.Id);
+            Assert.Equal(3, rows.Count);
+            Assert.True(rows[1].IsBold);
+            Assert.False(rows[2].IsBold);
+            Assert.True(rows[3].IsBold);
         }
 
         [FactMySql]
         public void Issue1277_ReaderSync()
         {
-            using (var conn = Provider.GetMySqlConnection())
-            {
-                try { conn.Execute("drop table Issue1277_Test"); } catch { /* don't care */ }
-                conn.Execute("create table Issue1277_Test (Id int not null, IsBold tinyint not null);");
-                conn.Execute("insert Issue1277_Test (Id, IsBold) values (1,1);");
-                conn.Execute("insert Issue1277_Test (Id, IsBold) values (2,0);");
-                conn.Execute("insert Issue1277_Test (Id, IsBold) values (3,1);");
+            using var conn = Provider.GetMySqlConnection();
 
-                using (var reader = conn.ExecuteReader(
-                    "select * from Issue1277_Test where Id < @id",
-                    new { id = 42 }))
-                {
-                    var table = new DataTable();
-                    table.Load(reader);
-                    Assert.Equal(2, table.Columns.Count);
-                    Assert.Equal(3, table.Rows.Count);
-                }
+            try { conn.Execute("drop table Issue1277_Test"); } catch { /* don't care */ }
+            conn.Execute("create table Issue1277_Test (Id int not null, IsBold tinyint not null);");
+            conn.Execute("insert Issue1277_Test (Id, IsBold) values (1,1);");
+            conn.Execute("insert Issue1277_Test (Id, IsBold) values (2,0);");
+            conn.Execute("insert Issue1277_Test (Id, IsBold) values (3,1);");
+
+            using (var reader = conn.ExecuteReader(
+                "select * from Issue1277_Test where Id < @id",
+                new { id = 42 }))
+            {
+                var table = new DataTable();
+                table.Load(reader);
+                Assert.Equal(2, table.Columns.Count);
+                Assert.Equal(3, table.Rows.Count);
             }
         }
 
         [FactMySql]
         public async Task Issue1277_ReaderAsync()
         {
-            using (var conn = Provider.GetMySqlConnection())
-            {
-                try { await conn.ExecuteAsync("drop table Issue1277_Test"); } catch { /* don't care */ }
-                await conn.ExecuteAsync("create table Issue1277_Test (Id int not null, IsBold tinyint not null);");
-                await conn.ExecuteAsync("insert Issue1277_Test (Id, IsBold) values (1,1);");
-                await conn.ExecuteAsync("insert Issue1277_Test (Id, IsBold) values (2,0);");
-                await conn.ExecuteAsync("insert Issue1277_Test (Id, IsBold) values (3,1);");
+            using var conn = Provider.GetMySqlConnection();
 
-                using (var reader = await conn.ExecuteReaderAsync(
-                    "select * from Issue1277_Test where Id < @id",
-                    new { id = 42 }))
-                {
-                    var table = new DataTable();
-                    table.Load(reader);
-                    Assert.Equal(2, table.Columns.Count);
-                    Assert.Equal(3, table.Rows.Count);
-                }
+            try { await conn.ExecuteAsync("drop table Issue1277_Test"); } catch { /* don't care */ }
+            await conn.ExecuteAsync("create table Issue1277_Test (Id int not null, IsBold tinyint not null);");
+            await conn.ExecuteAsync("insert Issue1277_Test (Id, IsBold) values (1,1);");
+            await conn.ExecuteAsync("insert Issue1277_Test (Id, IsBold) values (2,0);");
+            await conn.ExecuteAsync("insert Issue1277_Test (Id, IsBold) values (3,1);");
+
+            using (var reader = await conn.ExecuteReaderAsync(
+                "select * from Issue1277_Test where Id < @id",
+                new { id = 42 }))
+            {
+                var table = new DataTable();
+                table.Load(reader);
+                Assert.Equal(2, table.Columns.Count);
+                Assert.Equal(3, table.Rows.Count);
             }
         }
 

--- a/tests/Dapper.Tests/Providers/OLDEBTests.cs
+++ b/tests/Dapper.Tests/Providers/OLDEBTests.cs
@@ -22,61 +22,52 @@ namespace Dapper.Tests
         [Fact]
         public void TestOleDbParameters()
         {
-            using (var conn = GetOleDbConnection())
-            {
-                var row = conn.Query("select Id = ?, Age = ?",
-                    new { foo = 12, bar = 23 } // these names DO NOT MATTER!!!
-                ).Single();
-                int age = row.Age;
-                int id = row.Id;
-                Assert.Equal(23, age);
-                Assert.Equal(12, id);
-            }
+            using var conn = GetOleDbConnection();
+
+            var row = conn.Query("select Id = ?, Age = ?",
+                new { foo = 12, bar = 23 } // these names DO NOT MATTER!!!
+            ).Single();
+            int age = row.Age;
+            int id = row.Id;
+            Assert.Equal(23, age);
+            Assert.Equal(12, id);
         }
 
         [Fact]
         public void PseudoPositionalParameters_Simple()
         {
-            using (var connection = GetOleDbConnection())
-            {
-                int value = connection.Query<int>("select ?x? + ?y_2? + ?z?", new { x = 1, y_2 = 3, z = 5, z2 = 24 }).Single();
-                Assert.Equal(9, value);
-            }
+            using var connection = GetOleDbConnection();
+            int value = connection.Query<int>("select ?x? + ?y_2? + ?z?", new { x = 1, y_2 = 3, z = 5, z2 = 24 }).Single();
+            Assert.Equal(9, value);
         }
 
         [Fact]
         public void Issue601_InternationalParameterNamesWork_OleDb()
         {
             // pseudo-positional
-            using (var connection = GetOleDbConnection())
-            {
-                int value = connection.QuerySingle<int>("select ?æøå٦?", new { æøå٦ = 42 });
-            }
+            using var connection = GetOleDbConnection();
+            int value = connection.QuerySingle<int>("select ?æøå٦?", new { æøå٦ = 42 });
         }
 
         [Fact]
         public void PseudoPositionalParameters_Dynamic()
         {
-            using (var connection = GetOleDbConnection())
-            {
-                var args = new DynamicParameters();
-                args.Add("x", 1);
-                args.Add("y_2", 3);
-                args.Add("z", 5);
-                args.Add("z2", 24);
-                int value = connection.Query<int>("select ?x? + ?y_2? + ?z?", args).Single();
-                Assert.Equal(9, value);
-            }
+            using var connection = GetOleDbConnection();
+            var args = new DynamicParameters();
+            args.Add("x", 1);
+            args.Add("y_2", 3);
+            args.Add("z", 5);
+            args.Add("z2", 24);
+            int value = connection.Query<int>("select ?x? + ?y_2? + ?z?", args).Single();
+            Assert.Equal(9, value);
         }
 
         [Fact]
         public void PseudoPositionalParameters_ReusedParameter()
         {
-            using (var connection = GetOleDbConnection())
-            {
-                var ex = Assert.Throws<InvalidOperationException>(() => connection.Query<int>("select ?x? + ?y_2? + ?x?", new { x = 1, y_2 = 3 }).Single());
-                Assert.Equal("When passing parameters by position, each parameter can only be referenced once", ex.Message);
-            }
+            using var connection = GetOleDbConnection();
+            var ex = Assert.Throws<InvalidOperationException>(() => connection.Query<int>("select ?x? + ?y_2? + ?x?", new { x = 1, y_2 = 3 }).Single());
+            Assert.Equal("When passing parameters by position, each parameter can only be referenced once", ex.Message);
         }
 
         [Fact]
@@ -85,87 +76,76 @@ namespace Dapper.Tests
             const string sql = @"select s1.value as id, s2.value as score 
                         from string_split('1,2,3,4,5',',') s1, string_split('1,2,3,4,5',',') s2
                         where s1.value in ?ids? and s2.value = ?score?";
-            using (var connection = GetOleDbConnection())
-            {
-                const int score = 2;
-                int[] ids = { 1, 2, 5, 7 };
-                var list = connection.Query<int>(sql, new { ids, score }).AsList();
-                list.Sort();
-                Assert.Equal("1,2,5", string.Join(",", list));
-            }
+            using var connection = GetOleDbConnection();
+
+            const int score = 2;
+            int[] ids = { 1, 2, 5, 7 };
+            var list = connection.Query<int>(sql, new { ids, score }).AsList();
+            list.Sort();
+            Assert.Equal("1,2,5", string.Join(",", list));
         }
 
         [Fact]
         public void Issue569_SO38527197_PseudoPositionalParameters_In()
         {
-            using (var connection = GetOleDbConnection())
-            {
-                int[] ids = { 1, 2, 5, 7 };
-                var list = connection.Query<int>("select * from string_split('1,2,3,4,5',',') where value in ?ids?", new { ids }).AsList();
-                list.Sort();
-                Assert.Equal("1,2,5", string.Join(",", list));
-            }
+            using var connection = GetOleDbConnection();
+            int[] ids = { 1, 2, 5, 7 };
+            var list = connection.Query<int>("select * from string_split('1,2,3,4,5',',') where value in ?ids?", new { ids }).AsList();
+            list.Sort();
+            Assert.Equal("1,2,5", string.Join(",", list));
         }
 
         [Fact]
         public void PseudoPositional_CanUseVariable()
         {
-            using (var connection = GetOleDbConnection())
-            {
-                const int id = 42;
-                var row = connection.QuerySingle("declare @id int = ?id?; select @id as [A], @id as [B];", new { id });
-                int a = (int)row.A;
-                int b = (int)row.B;
-                Assert.Equal(42, a);
-                Assert.Equal(42, b);
-            }
+            using var connection = GetOleDbConnection();
+            const int id = 42;
+            var row = connection.QuerySingle("declare @id int = ?id?; select @id as [A], @id as [B];", new { id });
+            int a = (int)row.A;
+            int b = (int)row.B;
+            Assert.Equal(42, a);
+            Assert.Equal(42, b);
         }
 
         [Fact]
         public void PseudoPositional_CannotUseParameterMultipleTimes()
         {
-            using (var connection = GetOleDbConnection())
+            using var connection = GetOleDbConnection();
+            var ex = Assert.Throws<InvalidOperationException>(() =>
             {
-                var ex = Assert.Throws<InvalidOperationException>(() =>
-                {
-                    const int id = 42;
-                    connection.QuerySingle("select ?id? as [A], ?id? as [B];", new { id });
-                });
-                Assert.Equal("When passing parameters by position, each parameter can only be referenced once", ex.Message);
-            }
+                const int id = 42;
+                connection.QuerySingle("select ?id? as [A], ?id? as [B];", new { id });
+            });
+            Assert.Equal("When passing parameters by position, each parameter can only be referenced once", ex.Message);
         }
 
         [Fact]
         public void PseudoPositionalParameters_ExecSingle()
         {
-            using (var connection = GetOleDbConnection())
-            {
-                var data = new { x = 6 };
-                connection.Execute("create table #named_single(val int not null)");
-                int count = connection.Execute("insert #named_single (val) values (?x?)", data);
-                int sum = (int)connection.ExecuteScalar("select sum(val) from #named_single");
-                Assert.Equal(1, count);
-                Assert.Equal(6, sum);
-            }
+            using var connection = GetOleDbConnection();
+            var data = new { x = 6 };
+            connection.Execute("create table #named_single(val int not null)");
+            int count = connection.Execute("insert #named_single (val) values (?x?)", data);
+            int sum = (int)connection.ExecuteScalar("select sum(val) from #named_single");
+            Assert.Equal(1, count);
+            Assert.Equal(6, sum);
         }
 
         [Fact]
         public void PseudoPositionalParameters_ExecMulti()
         {
-            using (var connection = GetOleDbConnection())
+            using var connection = GetOleDbConnection();
+            var data = new[]
             {
-                var data = new[]
-                {
-                    new { x = 1, y = 1 },
-                    new { x = 3, y = 1 },
-                    new { x = 6, y = 1 },
-                };
-                connection.Execute("create table #named_multi(val int not null)");
-                int count = connection.Execute("insert #named_multi (val) values (?x?)", data);
-                int sum = (int)connection.ExecuteScalar("select sum(val) from #named_multi");
-                Assert.Equal(3, count);
-                Assert.Equal(10, sum);
-            }
+                new { x = 1, y = 1 },
+                new { x = 3, y = 1 },
+                new { x = 6, y = 1 },
+            };
+            connection.Execute("create table #named_multi(val int not null)");
+            int count = connection.Execute("insert #named_multi (val) values (?x?)", data);
+            int sum = (int)connection.ExecuteScalar("select sum(val) from #named_multi");
+            Assert.Equal(3, count);
+            Assert.Equal(10, sum);
         }
 
         [Fact]
@@ -178,21 +158,20 @@ SET @customerCode = ? -- ODBC parameter
 
 SELECT @since as [Since], @customerCode as [Code]";
 
-            using (var connection = GetOleDbConnection())
-            {
-                DateTime? since = null; // DateTime.Now.Date;
-                const string code = null;  // "abc";
-                var row = connection.QuerySingle(sql, new
-                {
-                    since,
-                    customerCode = code
-                });
-                var a = (DateTime?)row.Since;
-                var b = (string)row.Code;
+            using var connection = GetOleDbConnection();
 
-                Assert.Equal(since, a);
-                Assert.Equal(code, b);
-            }
+            DateTime? since = null; // DateTime.Now.Date;
+            const string code = null;  // "abc";
+            var row = connection.QuerySingle(sql, new
+            {
+                since,
+                customerCode = code
+            });
+            var a = (DateTime?)row.Since;
+            var b = (string)row.Code;
+
+            Assert.Equal(since, a);
+            Assert.Equal(code, b);
         }
 
         [Fact]
@@ -205,21 +184,20 @@ SET @customerCode = ?customerCode? -- ODBC parameter
 
 SELECT @since as [Since], @customerCode as [Code]";
 
-            using (var connection = GetOleDbConnection())
-            {
-                DateTime? since = null; // DateTime.Now.Date;
-                const string code = null;  // "abc";
-                var row = connection.QuerySingle(sql, new
-                {
-                    since,
-                    customerCode = code
-                });
-                var a = (DateTime?)row.Since;
-                var b = (string)row.Code;
+            using var connection = GetOleDbConnection();
 
-                Assert.Equal(since, a);
-                Assert.Equal(code, b);
-            }
+            DateTime? since = null; // DateTime.Now.Date;
+            const string code = null;  // "abc";
+            var row = connection.QuerySingle(sql, new
+            {
+                since,
+                customerCode = code
+            });
+            var a = (DateTime?)row.Since;
+            var b = (string)row.Code;
+
+            Assert.Equal(since, a);
+            Assert.Equal(code, b);
         }
 
         [Fact]
@@ -232,23 +210,22 @@ SET @customerCode = ? -- ODBC parameter
 
 SELECT @since as [Since], @customerCode as [Code]";
 
-            using (var connection = GetOleDbConnection())
-            {
-                DateTime? since = null; // DateTime.Now.Date;
-                const string code = null;  // "abc";
-                using (var multi = await connection.QueryMultipleAsync(sql, new
-                {
-                    since,
-                    customerCode = code
-                }).ConfigureAwait(false))
-                {
-                    var row = await multi.ReadSingleAsync().ConfigureAwait(false);
-                    var a = (DateTime?)row.Since;
-                    var b = (string)row.Code;
+            using var connection = GetOleDbConnection();
 
-                    Assert.Equal(a, since);
-                    Assert.Equal(b, code);
-                }
+            DateTime? since = null; // DateTime.Now.Date;
+            const string code = null;  // "abc";
+            using (var multi = await connection.QueryMultipleAsync(sql, new
+            {
+                since,
+                customerCode = code
+            }).ConfigureAwait(false))
+            {
+                var row = await multi.ReadSingleAsync().ConfigureAwait(false);
+                var a = (DateTime?)row.Since;
+                var b = (string)row.Code;
+
+                Assert.Equal(a, since);
+                Assert.Equal(b, code);
             }
         }
 
@@ -262,23 +239,22 @@ SET @customerCode = ?customerCode? -- ODBC parameter
 
 SELECT @since as [Since], @customerCode as [Code]";
 
-            using (var connection = GetOleDbConnection())
-            {
-                DateTime? since = null; // DateTime.Now.Date;
-                const string code = null;  // "abc";
-                using (var multi = await connection.QueryMultipleAsync(sql, new
-                {
-                    since,
-                    customerCode = code
-                }).ConfigureAwait(false))
-                {
-                    var row = await multi.ReadSingleAsync().ConfigureAwait(false);
-                    var a = (DateTime?)row.Since;
-                    var b = (string)row.Code;
+            using var connection = GetOleDbConnection();
 
-                    Assert.Equal(a, since);
-                    Assert.Equal(b, code);
-                }
+            DateTime? since = null; // DateTime.Now.Date;
+            const string code = null;  // "abc";
+            using (var multi = await connection.QueryMultipleAsync(sql, new
+            {
+                since,
+                customerCode = code
+            }).ConfigureAwait(false))
+            {
+                var row = await multi.ReadSingleAsync().ConfigureAwait(false);
+                var a = (DateTime?)row.Since;
+                var b = (string)row.Code;
+
+                Assert.Equal(a, since);
+                Assert.Equal(b, code);
             }
         }
     }

--- a/tests/Dapper.Tests/Providers/PostgresqlTests.cs
+++ b/tests/Dapper.Tests/Providers/PostgresqlTests.cs
@@ -47,37 +47,35 @@ namespace Dapper.Tests
         [FactPostgresql]
         public void TestPostgresqlArrayParameters()
         {
-            using (var conn = GetOpenNpgsqlConnection())
-            {
-                IDbTransaction transaction = conn.BeginTransaction();
-                conn.Execute("create table tcat ( id serial not null, breed character varying(20) not null, name character varying (20) not null);");
-                conn.Execute("insert into tcat(breed, name) values(:Breed, :Name) ", Cats);
+            using var conn = GetOpenNpgsqlConnection();
 
-                var r = conn.Query<Cat>("select * from tcat where id=any(:catids)", new { catids = new[] { 1, 3, 5 } });
-                Assert.Equal(3, r.Count());
-                Assert.Equal(1, r.Count(c => c.Id == 1));
-                Assert.Equal(1, r.Count(c => c.Id == 3));
-                Assert.Equal(1, r.Count(c => c.Id == 5));
-                transaction.Rollback();
-            }
+            IDbTransaction transaction = conn.BeginTransaction();
+            conn.Execute("create table tcat ( id serial not null, breed character varying(20) not null, name character varying (20) not null);");
+            conn.Execute("insert into tcat(breed, name) values(:Breed, :Name) ", Cats);
+
+            var r = conn.Query<Cat>("select * from tcat where id=any(:catids)", new { catids = new[] { 1, 3, 5 } });
+            Assert.Equal(3, r.Count());
+            Assert.Equal(1, r.Count(c => c.Id == 1));
+            Assert.Equal(1, r.Count(c => c.Id == 3));
+            Assert.Equal(1, r.Count(c => c.Id == 5));
+            transaction.Rollback();
         }
 
         [FactPostgresql]
         public void TestPostgresqlListParameters()
         {
-            using (var conn = GetOpenNpgsqlConnection())
-            {
-                IDbTransaction transaction = conn.BeginTransaction();
-                conn.Execute("create table tcat ( id serial not null, breed character varying(20) not null, name character varying (20) not null);");
-                conn.Execute("insert into tcat(breed, name) values(:Breed, :Name) ", new List<Cat>(Cats));
+            using var conn = GetOpenNpgsqlConnection();
 
-                var r = conn.Query<Cat>("select * from tcat where id=any(:catids)", new { catids = new List<int> { 1, 3, 5 } });
-                Assert.Equal(3, r.Count());
-                Assert.Equal(1, r.Count(c => c.Id == 1));
-                Assert.Equal(1, r.Count(c => c.Id == 3));
-                Assert.Equal(1, r.Count(c => c.Id == 5));
-                transaction.Rollback();
-            }
+            IDbTransaction transaction = conn.BeginTransaction();
+            conn.Execute("create table tcat ( id serial not null, breed character varying(20) not null, name character varying (20) not null);");
+            conn.Execute("insert into tcat(breed, name) values(:Breed, :Name) ", new List<Cat>(Cats));
+
+            var r = conn.Query<Cat>("select * from tcat where id=any(:catids)", new { catids = new List<int> { 1, 3, 5 } });
+            Assert.Equal(3, r.Count());
+            Assert.Equal(1, r.Count(c => c.Id == 1));
+            Assert.Equal(1, r.Count(c => c.Id == 3));
+            Assert.Equal(1, r.Count(c => c.Id == 5));
+            transaction.Rollback();
         }
 
         private class CharTable
@@ -89,39 +87,36 @@ namespace Dapper.Tests
         [FactPostgresql]
         public void TestPostgresqlChar()
         {
-            using (var conn = GetOpenNpgsqlConnection())
-            {
-                var transaction = conn.BeginTransaction();
-                conn.Execute("create table chartable (id serial not null, charcolumn \"char\" not null);");
-                conn.Execute("insert into chartable(charcolumn) values('a');");
+            using var conn = GetOpenNpgsqlConnection();
 
-                var r = conn.Query<CharTable>("select * from chartable");
-                Assert.Single(r);
-                Assert.Equal('a', r.Single().CharColumn);
-                transaction.Rollback();
-            }
+            var transaction = conn.BeginTransaction();
+            conn.Execute("create table chartable (id serial not null, charcolumn \"char\" not null);");
+            conn.Execute("insert into chartable(charcolumn) values('a');");
+
+            var r = conn.Query<CharTable>("select * from chartable");
+            Assert.Single(r);
+            Assert.Equal('a', r.Single().CharColumn);
+            transaction.Rollback();
         }
 
         [FactPostgresql]
         public void TestPostgresqlSelectArray()
         {
-            using (var conn = GetOpenNpgsqlConnection())
-            {
-                var r = conn.Query<int[]>("select array[1,2,3]").ToList();
-                Assert.Single(r);
-                Assert.Equal(new[] { 1, 2, 3 }, r.Single());
-            }
+            using var conn = GetOpenNpgsqlConnection();
+
+            var r = conn.Query<int[]>("select array[1,2,3]").ToList();
+            Assert.Single(r);
+            Assert.Equal(new[] { 1, 2, 3 }, r.Single());
         }
 
         [FactPostgresql]
         public void TestPostgresqlDateTimeUsage()
         {
-            using (var conn = GetOpenNpgsqlConnection())
-            {
-                DateTime now = DateTime.UtcNow;
-                DateTime? nilA = now, nilB = null;
-                _ = conn.ExecuteScalar("SELECT @now, @nilA, @nilB::timestamp", new { now, nilA, nilB });
-            }
+            using var conn = GetOpenNpgsqlConnection();
+
+            DateTime now = DateTime.UtcNow;
+            DateTime? nilA = now, nilB = null;
+            _ = conn.ExecuteScalar("SELECT @now, @nilA, @nilB::timestamp", new { now, nilA, nilB });
         }
 
         [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]

--- a/tests/Dapper.Tests/Providers/SqliteTests.cs
+++ b/tests/Dapper.Tests/Providers/SqliteTests.cs
@@ -34,9 +34,7 @@ namespace Dapper.Tests
             {
                 try
                 {
-                    using (DatabaseProvider<SqliteProvider>.Instance.GetOpenConnection())
-                    {
-                    }
+                    using var _ = DatabaseProvider<SqliteProvider>.Instance.GetOpenConnection();
                 }
                 catch (Exception ex)
                 {
@@ -52,39 +50,37 @@ namespace Dapper.Tests
         [FactSqlite]
         public void Issue466_SqliteHatesOptimizations()
         {
-            using (var connection = GetSQLiteConnection())
-            {
-                SqlMapper.ResetTypeHandlers();
-                var row = connection.Query<HazNameId>("select 42 as Id").First();
-                Assert.Equal(42, row.Id);
-                row = connection.Query<HazNameId>("select 42 as Id").First();
-                Assert.Equal(42, row.Id);
+            using var connection = GetSQLiteConnection();
 
-                SqlMapper.ResetTypeHandlers();
-                row = connection.QueryFirst<HazNameId>("select 42 as Id");
-                Assert.Equal(42, row.Id);
-                row = connection.QueryFirst<HazNameId>("select 42 as Id");
-                Assert.Equal(42, row.Id);
-            }
+            SqlMapper.ResetTypeHandlers();
+            var row = connection.Query<HazNameId>("select 42 as Id").First();
+            Assert.Equal(42, row.Id);
+            row = connection.Query<HazNameId>("select 42 as Id").First();
+            Assert.Equal(42, row.Id);
+
+            SqlMapper.ResetTypeHandlers();
+            row = connection.QueryFirst<HazNameId>("select 42 as Id");
+            Assert.Equal(42, row.Id);
+            row = connection.QueryFirst<HazNameId>("select 42 as Id");
+            Assert.Equal(42, row.Id);
         }
 
         [FactSqlite]
         public async Task Issue466_SqliteHatesOptimizations_Async()
         {
-            using (var connection = GetSQLiteConnection())
-            {
-                SqlMapper.ResetTypeHandlers();
-                var row = (await connection.QueryAsync<HazNameId>("select 42 as Id").ConfigureAwait(false)).First();
-                Assert.Equal(42, row.Id);
-                row = (await connection.QueryAsync<HazNameId>("select 42 as Id").ConfigureAwait(false)).First();
-                Assert.Equal(42, row.Id);
+            using var connection = GetSQLiteConnection();
 
-                SqlMapper.ResetTypeHandlers();
-                row = await connection.QueryFirstAsync<HazNameId>("select 42 as Id").ConfigureAwait(false);
-                Assert.Equal(42, row.Id);
-                row = await connection.QueryFirstAsync<HazNameId>("select 42 as Id").ConfigureAwait(false);
-                Assert.Equal(42, row.Id);
-            }
+            SqlMapper.ResetTypeHandlers();
+            var row = (await connection.QueryAsync<HazNameId>("select 42 as Id").ConfigureAwait(false)).First();
+            Assert.Equal(42, row.Id);
+            row = (await connection.QueryAsync<HazNameId>("select 42 as Id").ConfigureAwait(false)).First();
+            Assert.Equal(42, row.Id);
+
+            SqlMapper.ResetTypeHandlers();
+            row = await connection.QueryFirstAsync<HazNameId>("select 42 as Id").ConfigureAwait(false);
+            Assert.Equal(42, row.Id);
+            row = await connection.QueryFirstAsync<HazNameId>("select 42 as Id").ConfigureAwait(false);
+            Assert.Equal(42, row.Id);
         }
     }
 
@@ -93,10 +89,8 @@ namespace Dapper.Tests
         [FactSqlite]
         public void DapperEnumValue_Sqlite()
         {
-            using (var connection = GetSQLiteConnection())
-            {
-                Common.DapperEnumValue(connection);
-            }
+            using var connection = GetSQLiteConnection();
+            Common.DapperEnumValue(connection);
         }
 
         
@@ -115,15 +109,14 @@ namespace Dapper.Tests
 
         private void Isse467_SqliteParameterNaming(bool prefix)
         {
-            using (var connection = GetSQLiteConnection())
-            {
-                var cmd = connection.CreateCommand();
-                cmd.CommandText = "select @foo";
-                const SqliteType type = SqliteType.Integer;
-                cmd.Parameters.Add(prefix ? "@foo" : "foo", type).Value = 42;
-                var i = Convert.ToInt32(cmd.ExecuteScalar());
-                Assert.Equal(42, i);
-            }
+            using var connection = GetSQLiteConnection();
+
+            var cmd = connection.CreateCommand();
+            cmd.CommandText = "select @foo";
+            const SqliteType type = SqliteType.Integer;
+            cmd.Parameters.Add(prefix ? "@foo" : "foo", type).Value = 42;
+            var i = Convert.ToInt32(cmd.ExecuteScalar());
+            Assert.Equal(42, i);
         }
 
         [FactSqlite]


### PR DESCRIPTION
I have to emphasize the fact that not all `using`s were made block-scoped, only those who would be functionally identical.

This is more of a reformatting for better readability