### PR TITLE
Revert $ check for OLEDB anonymous parameters

### DIFF
--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -2387,7 +2387,7 @@ namespace Dapper
         }
 
         // look for ? / @ / : *by itself*
-        private static readonly Regex smellsLikeOleDb = new(@"(?<![\p{L}\p{N}@_])[?@:$](?![\p{L}\p{N}@_])", RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant | RegexOptions.Compiled),
+        private static readonly Regex smellsLikeOleDb = new(@"(?<![\p{L}\p{N}@_])[?@:](?![\p{L}\p{N}@_])", RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant | RegexOptions.Compiled),
             literalTokens = new(@"(?<![\p{L}\p{N}_])\{=([\p{L}\p{N}_]+)\}", RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant | RegexOptions.Compiled),
             pseudoPositional = new(@"\?([\p{L}_][\p{L}\p{N}_]*)\?", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,7 @@ Note: to get the latest pre-release build, add ` -Pre` to the end of the command
 
 - infer command text without any whitespace as stored-procedure (#1975 via @mgravell)
 - add global `SupportLegacyParameterTokens` setting to enable or disable single-character parameter tokens (#1974 via @Giorgi)
+- revert `$` addition for legacy parameter tokens (#1979 via @mgravell)
 
 ### 2.1.4
 


### PR DESCRIPTION
the $ support added for DuckDB does not need to exacerbate the OLEDB parameter problem

partial revert from [here](https://github.com/DapperLib/Dapper/commit/8a68070b8e05e6ed6ff24a4f0d25ca2a156139a6#diff-a3effc0b61d15b590432233f593ae316ad897dfa9ced93180798fd013c36e27dR2383) - we don't expect *just* `$` for DuckDB