### PR TITLE
include ExplicitConstructorAttribute's targets to constructor&method 

### DIFF
--- a/Dapper/ExplicitConstructorAttribute.cs
+++ b/Dapper/ExplicitConstructorAttribute.cs
@@ -5,7 +5,7 @@ namespace Dapper
     /// <summary>
     /// Tell Dapper to use an explicit constructor, passing nulls or 0s for all parameters
     /// </summary>
-    [AttributeUsage(AttributeTargets.Constructor, AllowMultiple = false)]
+    [AttributeUsage(AttributeTargets.Constructor | AttributeTargets.Method, AllowMultiple = false)]
     public sealed class ExplicitConstructorAttribute : Attribute
     {
     }

--- a/Dapper/ExplicitConstructorAttribute.cs
+++ b/Dapper/ExplicitConstructorAttribute.cs
@@ -5,6 +5,9 @@ namespace Dapper
     /// <summary>
     /// Tell Dapper to use an explicit constructor, passing nulls or 0s for all parameters
     /// </summary>
+    /// <remarks>
+    /// Usage on methods is limited to the usage with Dapper.AOT (https://github.com/DapperLib/DapperAOT)
+    /// </remarks>
     [AttributeUsage(AttributeTargets.Constructor | AttributeTargets.Method, AllowMultiple = false)]
     public sealed class ExplicitConstructorAttribute : Attribute
     {


### PR DESCRIPTION
In [Dapper.AOT](https://github.com/DapperLib/DapperAOT) we are implementing a support for factory method construction of instances. As proposed by @mgravell - we can use existing `Dapper.ExplicitConstructorAttribute` for that - but we need to expand the attribute targets model.

PR link: [Non-trivial instance construction with factory methods #59](https://github.com/DapperLib/DapperAOT/pull/59);
Proposition link: [keep the name and change the allowable targets (C)](https://github.com/DapperLib/DapperAOT/pull/59#issuecomment-1742433726)