### PR TITLE
expand auto-sproc detection to handle more scenarios and explicit exclusions

### DIFF
--- a/Dapper.StrongName/Dapper.StrongName.csproj
+++ b/Dapper.StrongName/Dapper.StrongName.csproj
@@ -5,11 +5,12 @@
     <Title>Dapper (Strong Named)</Title>
     <Description>A high performance Micro-ORM supporting SQL Server, MySQL, Sqlite, SqlCE, Firebird etc..</Description>
     <Authors>Sam Saffron;Marc Gravell;Nick Craver</Authors>
-    <TargetFrameworks>net461;netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;net5.0;net7.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DefineConstants>$(DefineConstants);STRONG_NAME</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/Dapper/CompiledRegex.cs
+++ b/Dapper/CompiledRegex.cs
@@ -1,0 +1,45 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Text.RegularExpressions;
+
+namespace Dapper;
+
+internal static partial class CompiledRegex
+{
+#if DEBUG && NET7_0_OR_GREATER // enables colorization in IDE
+    [StringSyntax("Regex")]
+#endif
+    private const string
+        WhitespaceOrReservedPattern = @"[\s;/\-+*]|^vacuum$",
+        LegacyParameterPattern = @"(?<![\p{L}\p{N}@_])[?@:](?![\p{L}\p{N}@_])", // look for ? / @ / : *by itself* - see SupportLegacyParameterTokens
+        LiteralTokensPattern = @"(?<![\p{L}\p{N}_])\{=([\p{L}\p{N}_]+)\}", // look for {=abc} to inject member abc as a literal
+        PseudoPositionalPattern = @"\?([\p{L}_][\p{L}\p{N}_]*)\?"; // look for ?abc? for the purpose of subst back to ? using member abc
+
+
+#if NET7_0_OR_GREATER // use regex code generator (this doesn't work for down-level, even if you define the attribute manually)
+    [GeneratedRegex(LegacyParameterPattern, RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant)]
+    private static partial Regex LegacyParameterGen();
+
+    [GeneratedRegex(LiteralTokensPattern, RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant)]
+    private static partial Regex LiteralTokensGen();
+
+    [GeneratedRegex(PseudoPositionalPattern, RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant)]
+    private static partial Regex PseudoPositionalGen();
+
+    [GeneratedRegex(WhitespaceOrReservedPattern, RegexOptions.IgnoreCase, "en-US")]
+    private static partial Regex WhitespaceOrReservedGen();
+
+    internal static Regex LegacyParameter => LegacyParameterGen();
+    internal static Regex LiteralTokens => LiteralTokensGen();
+    internal static Regex PseudoPositional => PseudoPositionalGen();
+    internal static Regex WhitespaceOrReserved => WhitespaceOrReservedGen();
+#else
+    internal static Regex LegacyParameter { get; }
+        = new(LegacyParameterPattern, RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant | RegexOptions.Compiled);
+    internal static Regex LiteralTokens { get; }
+        = new(LiteralTokensPattern, RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant | RegexOptions.Compiled);
+    internal static Regex PseudoPositional { get; }
+    = new(PseudoPositionalPattern, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
+    internal static Regex WhitespaceOrReserved { get; }
+        = new(WhitespaceOrReservedPattern, RegexOptions.Compiled | RegexOptions.IgnoreCase);
+#endif
+}

--- a/Dapper/Dapper.csproj
+++ b/Dapper/Dapper.csproj
@@ -5,7 +5,7 @@
     <PackageTags>orm;sql;micro-orm</PackageTags>
     <Description>A high performance Micro-ORM supporting SQL Server, MySQL, Sqlite, SqlCE, Firebird etc..</Description>
     <Authors>Sam Saffron;Marc Gravell;Nick Craver</Authors>
-    <TargetFrameworks>net461;netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;net5.0;net7.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/Dapper/Global.cs
+++ b/Dapper/Global.cs
@@ -1,0 +1,4 @@
+﻿using System.Runtime.CompilerServices;
+#if !STRONG_NAME
+[assembly: InternalsVisibleTo("Dapper.Tests")]
+#endif

--- a/Dapper/PublicAPI/net7.0/PublicAPI.Shipped.txt
+++ b/Dapper/PublicAPI/net7.0/PublicAPI.Shipped.txt
@@ -1,0 +1,6 @@
+﻿#nullable enable
+Dapper.SqlMapper.GridReader.DisposeAsync() -> System.Threading.Tasks.ValueTask
+Dapper.SqlMapper.GridReader.ReadUnbufferedAsync() -> System.Collections.Generic.IAsyncEnumerable<dynamic!>!
+Dapper.SqlMapper.GridReader.ReadUnbufferedAsync<T>() -> System.Collections.Generic.IAsyncEnumerable<T>!
+static Dapper.SqlMapper.QueryUnbufferedAsync(this System.Data.Common.DbConnection! cnn, string! sql, object? param = null, System.Data.Common.DbTransaction? transaction = null, int? commandTimeout = null, System.Data.CommandType? commandType = null) -> System.Collections.Generic.IAsyncEnumerable<dynamic!>!
+static Dapper.SqlMapper.QueryUnbufferedAsync<T>(this System.Data.Common.DbConnection! cnn, string! sql, object? param = null, System.Data.Common.DbTransaction? transaction = null, int? commandTimeout = null, System.Data.CommandType? commandType = null) -> System.Collections.Generic.IAsyncEnumerable<T>!

--- a/Dapper/PublicAPI/net7.0/PublicAPI.Unshipped.txt
+++ b/Dapper/PublicAPI/net7.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+﻿#nullable enable

--- a/Dapper/SqlMapper.DapperRow.Descriptor.cs
+++ b/Dapper/SqlMapper.DapperRow.Descriptor.cs
@@ -13,8 +13,8 @@ namespace Dapper
             {
                 public override ICustomTypeDescriptor GetExtendedTypeDescriptor(object instance)
                     => new DapperRowTypeDescriptor(instance);
-                public override ICustomTypeDescriptor GetTypeDescriptor(Type objectType, object instance)
-                    => new DapperRowTypeDescriptor(instance);
+                public override ICustomTypeDescriptor GetTypeDescriptor(Type objectType, object? instance)
+                    => new DapperRowTypeDescriptor(instance!);
             }
 
             //// in theory we could implement this for zero-length results to bind; would require
@@ -57,7 +57,7 @@ namespace Dapper
 
                 EventDescriptorCollection ICustomTypeDescriptor.GetEvents() => EventDescriptorCollection.Empty;
 
-                EventDescriptorCollection ICustomTypeDescriptor.GetEvents(Attribute[] attributes) => EventDescriptorCollection.Empty;
+                EventDescriptorCollection ICustomTypeDescriptor.GetEvents(Attribute[]? attributes) => EventDescriptorCollection.Empty;
 
                 internal static PropertyDescriptorCollection GetProperties(DapperRow row) => GetProperties(row?.table, row);
                 internal static PropertyDescriptorCollection GetProperties(DapperTable? table, IDictionary<string,object?>? row = null)
@@ -75,9 +75,9 @@ namespace Dapper
                 }
                 PropertyDescriptorCollection ICustomTypeDescriptor.GetProperties() => GetProperties(_row);
 
-                PropertyDescriptorCollection ICustomTypeDescriptor.GetProperties(Attribute[] attributes) => GetProperties(_row);
+                PropertyDescriptorCollection ICustomTypeDescriptor.GetProperties(Attribute[]? attributes) => GetProperties(_row);
 
-                object ICustomTypeDescriptor.GetPropertyOwner(PropertyDescriptor pd) => _row;
+                object ICustomTypeDescriptor.GetPropertyOwner(PropertyDescriptor? pd) => _row;
             }
 
             private sealed class RowBoundPropertyDescriptor : PropertyDescriptor
@@ -95,10 +95,10 @@ namespace Dapper
                 public override bool ShouldSerializeValue(object component) => ((DapperRow)component).TryGetValue(_index, out _);
                 public override Type ComponentType => typeof(DapperRow);
                 public override Type PropertyType => _type;
-                public override object GetValue(object component)
-                    => ((DapperRow)component).TryGetValue(_index, out var val) ? (val ?? DBNull.Value): DBNull.Value;
-                public override void SetValue(object component, object? value)
-                    => ((DapperRow)component).SetValue(_index, value is DBNull ? null : value);
+                public override object GetValue(object? component)
+                    => ((DapperRow)component!).TryGetValue(_index, out var val) ? (val ?? DBNull.Value): DBNull.Value;
+                public override void SetValue(object? component, object? value)
+                    => ((DapperRow)component!).SetValue(_index, value is DBNull ? null : value);
             }
         }
     }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,7 +21,7 @@
     <IncludeSymbols>false</IncludeSymbols>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>11</LangVersion>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
     <PackageReadmeFile>readme.md</PackageReadmeFile>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,9 @@ skip_commits:
   files:
     - '**/*.md'
 
+install:
+  - choco install dotnet-sdk --version 7.0.402
+
 environment:
   Appveyor: true
   # Postgres

--- a/tests/Dapper.Tests/Dapper.Tests.csproj
+++ b/tests/Dapper.Tests/Dapper.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyName>Dapper.Tests</AssemblyName>
     <Description>Dapper Core Test Suite</Description>
-    <TargetFrameworks>net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);MSSQLCLIENT</DefineConstants>
     <NoWarn>$(NoWarn);IDE0017;IDE0034;IDE0037;IDE0039;IDE0042;IDE0044;IDE0051;IDE0052;IDE0059;IDE0060;IDE0063;IDE1006;xUnit1004;CA1806;CA1816;CA1822;CA1825;CA2208</NoWarn>
     <Nullable>enable</Nullable>

--- a/tests/Dapper.Tests/ProcedureTests.cs
+++ b/tests/Dapper.Tests/ProcedureTests.cs
@@ -317,5 +317,27 @@ namespace Dapper.Tests
             var result = await connection.QuerySingleAsync<int>(sql);
             Assert.Equal(42, result);
         }
+
+        [Theory]
+        [InlineData("foo", CommandType.StoredProcedure)]
+        [InlineData("foo;", CommandType.Text)]
+        [InlineData("foo bar", CommandType.Text)]
+        [InlineData("foo bar;", CommandType.Text)]
+        [InlineData("vacuum", CommandType.Text)]
+        [InlineData("vacuum;", CommandType.Text)]
+        [InlineData("FOO", CommandType.StoredProcedure)]
+        [InlineData("FOO;", CommandType.Text)]
+        [InlineData("FOO BAR", CommandType.Text)]
+        [InlineData("FOO BAR;", CommandType.Text)]
+        [InlineData("VACUUM", CommandType.Text)]
+        [InlineData("VACUUM;", CommandType.Text)]
+
+        // comments imply text
+        [InlineData("foo--bar", CommandType.Text)]
+        [InlineData("foo/*bar*/", CommandType.Text)]
+        public void InferCommandType(string sql, CommandType commandType)
+        {
+            Assert.Equal(commandType, CommandDefinition.InferCommandType(sql));
+        }
     }
 }


### PR DESCRIPTION
- expand auto-sproc detection to handle more scenarios and explicit exclusions
- add net7 target
- use regex generator when available (net7+)
- fix #1984