### PR TITLE
AppVeyor: Restore MySQL

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,6 +38,7 @@ init:
   - git config --global core.autocrlf input
   - SET PATH=%POSTGRES_PATH%\bin;%MYSQL_PATH%\bin;%PATH%
   - net start MSSQL$SQL2019
+  - ps: Start-Service MySQL80
     
 nuget:
   disable_publish_on_pr: true
@@ -46,7 +47,7 @@ build_script:
   # Postgres
   - createdb test
   # MySQL
-  # - mysql -e "create database test;" --user=root
+  - mysql -e "create database test;" --user=root
   # Our stuff
   - ps: .\build.ps1 -PullRequestNumber "$env:APPVEYOR_PULL_REQUEST_NUMBER" -CreatePackages $true
 


### PR DESCRIPTION
Looks like the image was borked with MySQL 8 went in (because it's still trying to start 5.7), see https://github.com/appveyor/ci/issues/3894.