### PR TITLE
chore: Update Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,7 +4,7 @@ Dapper - a simple object mapper for .Net
 
 Release Notes
 -------------
-Located at [dapperlib.github.io/Dapper](https://dapperlib.github.io/Dapper/)
+Located at [https://github.com/DapperLib/Dapper/releases](https://github.com/DapperLib/Dapper/releases/)
 
 Packages
 --------


### PR DESCRIPTION
Updates url to point to new release notes publication.  The .io one said it wasn't in use anymore and to use the github.com releases information.