### PR TITLE
Improve null handling on ICustomQueryParameter (and add new DbString .ctor)

### DIFF
--- a/Dapper/DbString.cs
+++ b/Dapper/DbString.cs
@@ -28,6 +28,17 @@ namespace Dapper
             Length = -1;
             IsAnsi = IsAnsiDefault;
         }
+
+        /// <summary>
+        /// Create a new DbString
+        /// </summary>
+        public DbString(string? value, int length = -1)
+        {
+            Value = value;
+            Length = length;
+            IsAnsi = IsAnsiDefault;
+        }
+
         /// <summary>
         /// Ansi vs Unicode 
         /// </summary>
@@ -44,12 +55,13 @@ namespace Dapper
         /// The value of the string
         /// </summary>
         public string? Value { get; set; }
-        
+
         /// <summary>
         /// Gets a string representation of this DbString.
         /// </summary>
-        public override string ToString() =>
-            $"Dapper.DbString (Value: '{Value}', Length: {Length}, IsAnsi: {IsAnsi}, IsFixedLength: {IsFixedLength})";
+        public override string ToString() => Value is null
+            ? $"Dapper.DbString (Value: null, Length: {Length}, IsAnsi: {IsAnsi}, IsFixedLength: {IsFixedLength})"
+            : $"Dapper.DbString (Value: '{Value}', Length: {Length}, IsAnsi: {IsAnsi}, IsFixedLength: {IsFixedLength})";
 
         /// <summary>
         /// Add the parameter to the command... internal use only

--- a/Dapper/PublicAPI.Shipped.txt
+++ b/Dapper/PublicAPI.Shipped.txt
@@ -30,6 +30,7 @@ Dapper.CustomPropertyTypeMap.GetMember(string! columnName) -> Dapper.SqlMapper.I
 Dapper.DbString
 Dapper.DbString.AddParameter(System.Data.IDbCommand! command, string! name) -> void
 Dapper.DbString.DbString() -> void
+Dapper.DbString.DbString(string? value, int length = -1) -> void
 Dapper.DbString.IsAnsi.get -> bool
 Dapper.DbString.IsAnsi.set -> void
 Dapper.DbString.IsFixedLength.get -> bool
@@ -323,6 +324,7 @@ static Dapper.SqlMapper.Settings.UseSingleRowOptimization.set -> void
 static Dapper.SqlMapper.SetTypeMap(System.Type! type, Dapper.SqlMapper.ITypeMap? map) -> void
 static Dapper.SqlMapper.SetTypeName(this System.Data.DataTable! table, string! typeName) -> void
 static Dapper.SqlMapper.ThrowDataException(System.Exception! ex, int index, System.Data.IDataReader! reader, object? value) -> void
+static Dapper.SqlMapper.ThrowNullCustomQueryParameter(string! name) -> void
 static Dapper.SqlMapper.TypeHandlerCache<T>.Parse(object! value) -> T?
 static Dapper.SqlMapper.TypeHandlerCache<T>.SetValue(System.Data.IDbDataParameter! parameter, object! value) -> void
 static Dapper.SqlMapper.TypeMapProvider -> System.Func<System.Type!, Dapper.SqlMapper.ITypeMap!>!


### PR DESCRIPTION
1. give clearer error messages when an ICustomQueryParameter is null
2. provide a convenience .ctor on DbString

Fixes #1425