### PR TITLE
Fixed documentation to read better

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -444,7 +444,7 @@ Limitations and caveats
 ---------------------
 Dapper caches information about every query it runs, this allows it to materialize objects quickly and process parameters quickly. The current implementation caches this information in a `ConcurrentDictionary` object. Statements that are only used once are routinely flushed from this cache. Still, if you are generating SQL strings on the fly without using parameters it is possible you may hit memory issues.
 
-Dapper's simplicity means that many feature that ORMs ship with are stripped out. It worries about the 95% scenario, and gives you the tools you need most of the time. It doesn't attempt to solve every problem.
+Dapper's simplicity means that many features that ORMs ship with are stripped out. It worries about the 95% scenario, and gives you the tools you need most of the time. It doesn't attempt to solve every problem.
 
 Will Dapper work with my DB provider?
 ---------------------


### PR DESCRIPTION
Fixed the following line in the *_Readme.md_* file.


Limitations and caveats
---------------------

Dapper's simplicity means that many `features` that ORMs ship with are stripped out. It worries about the 95% scenario, and gives you the tools you need most of the time. It doesn't attempt to solve every problem.