### PR TITLE
Fix: Slowness when using large number of dynamic parameters #1537

### DIFF
--- a/Dapper/DynamicParameters.cs
+++ b/Dapper/DynamicParameters.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -222,6 +223,9 @@ namespace Dapper
                 }
             }
 
+            HashSet<string> addedParameters = new HashSet<string>(command.Parameters.Cast<IDbDataParameter>()
+                .Select(x => x.ParameterName), comparer: StringComparer.CurrentCultureIgnoreCase);
+
             foreach (var param in parameters.Values)
             {
                 if (param.CameFromTemplate) continue;
@@ -250,7 +254,7 @@ namespace Dapper
                 }
                 else
                 {
-                    bool add = !command.Parameters.Contains(name);
+                    bool add = !addedParameters.Contains(name);
                     IDbDataParameter p;
                     if (add)
                     {
@@ -296,6 +300,8 @@ namespace Dapper
                     }
                     param.AttachedParam = p;
                 }
+
+                addedParameters.Add(name);
             }
 
             // note: most non-privileged implementations would use: this.ReplaceLiterals(command);


### PR DESCRIPTION
Calling `command.Parameters.Contains(name)` for every parameter is an n-squared algorithm for many database implementations and can cause performance when there is a large number of parameters. This fixes that performance issue.