### PR TITLE
Add MariaDB test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,14 @@ jobs:
         env:
           MYSQL_ROOT_PASSWORD: root
           MYSQL_DATABASE: test
+      mariadb:
+        image: mariadb
+        ports:
+          - 3307:3306/tcp
+        env:
+          MARIADB_ROOT_PASSWORD: root
+          MARIADB_DATABASE: test
+        options: --health-cmd "healthcheck.sh --connect --innodb_initialized" --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
     - name: Checkout code
       uses: actions/checkout@v1
@@ -49,5 +57,6 @@ jobs:
         OLEDBConnectionString: Provider=SQLOLEDB;Server=tcp:localhost,${{ job.services.sqlserver.ports[1433] }};Database=tempdb;User Id=sa;Password=Password.;
         PostgesConnectionString: Server=localhost;Port=${{ job.services.postgres.ports[5432] }};Database=test;User Id=postgres;Password=postgres;
         SqlServerConnectionString: Server=tcp:localhost,${{ job.services.sqlserver.ports[1433] }};Database=tempdb;User Id=sa;Password=Password.;
+        MariaDBConnectionString: Server=localhost;Port=${{ job.services.mariadb.ports[3306] }};Uid=root;Pwd=root;Database=test;Allow User Variables=true
     - name: .NET Lib Pack
       run: dotnet pack Build.csproj --no-build -c Release /p:PackageOutputPath=%CD%\.nupkgs /p:CI=true

--- a/tests/Dapper.Tests/Providers/MariaDBTests.cs
+++ b/tests/Dapper.Tests/Providers/MariaDBTests.cs
@@ -1,0 +1,14 @@
+namespace Dapper.Tests
+{
+    /// <summary>
+    /// If Docker Desktop is installed, run the following command to start a container suitable for the tests.
+    /// <code>
+    /// docker run -d -p 3306:3306 --name Dapper.Tests.MariaDB -e MARIADB_DATABASE=tests -e MARIADB_USER=test -e MARIADB_PASSWORD=pass -e MARIADB_ROOT_PASSWORD=pass mariadb
+    /// </code>
+    /// </summary>
+    public sealed class MariaDBProvider : MySqlProvider
+    {
+        public override string GetConnectionString() =>
+            GetConnectionString("MariaDBConnectionString", "Server=localhost;Database=tests;Uid=test;Pwd=pass;");
+    }
+}

--- a/tests/Dapper.Tests/Providers/MySQLTests.cs
+++ b/tests/Dapper.Tests/Providers/MySQLTests.cs
@@ -13,7 +13,7 @@ namespace Dapper.Tests
     /// docker run -d -p 3306:3306 --name Dapper.Tests.MySQL -e MYSQL_DATABASE=tests -e MYSQL_USER=test -e MYSQL_PASSWORD=pass -e MYSQL_ROOT_PASSWORD=pass mysql
     /// </code>
     /// </summary>
-    public sealed class MySqlProvider : DatabaseProvider
+    public class MySqlProvider : DatabaseProvider
     {
         public override DbProviderFactory Factory => MySqlConnector.MySqlConnectorFactory.Instance;
         public override string GetConnectionString() =>


### PR DESCRIPTION
I can first understand what is actually different between MySQL and MariaDB, but it doesn't hurt to test.

Things like https://stackoverflow.com/questions/78627602/dapper-with-mariadb-stored-procedure-with-uuid-type-parameters show that there is a UUID type in MariaDB and not MySQL which might eventually need special handing within Dapper.