### PR TITLE
Make AddTypeHandlerImpl in SqlMapper thread safe

### DIFF
--- a/Dapper/PublicAPI.Unshipped.txt
+++ b/Dapper/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 ﻿#nullable enable
+static Dapper.SqlMapper.AddTypeHandlerImpl(System.Type! type, Dapper.SqlMapper.ITypeHandler? handler) -> void


### PR DESCRIPTION
As discussed in issue #1815, the current implementation of SqlMapper.AddTypeHandlerImpl is not thread-safe. When typeHandlers is cloned during concurrent access to this method, a race condition occurs because each thread maintains its own copy of typeHandlers. This can result in handlers added by some threads being lost. This fix addresses the issue to ensure thread safety.

Additionally, we propose to obsolete below overload version of AddTypeHandlerImpl:

```
void AddTypeHandlerImpl(Type type, ITypeHandler? handler, bool clone)
```

Also suggest making all overloads of AddTypeHandlerImpl non-public, as their method names indicate that they are intended for internal implementation, but that could be handled separately in the future.