### PR TITLE
Fix #2113

### DIFF
--- a/Dapper/CommandDefinition.cs
+++ b/Dapper/CommandDefinition.cs
@@ -11,16 +11,9 @@ namespace Dapper
     /// </summary>
     public readonly struct CommandDefinition
     {
-        internal static CommandDefinition ForCallback(object? parameters)
+        internal static CommandDefinition ForCallback(object? parameters, CommandFlags flags)
         {
-            if (parameters is DynamicParameters)
-            {
-                return new CommandDefinition(parameters);
-            }
-            else
-            {
-                return default;
-            }
+            return new CommandDefinition(parameters is DynamicParameters ? parameters : null, flags);
         }
 
         internal void OnCompleted()
@@ -113,9 +106,10 @@ namespace Dapper
             return System.Data.CommandType.StoredProcedure;
         }
 
-        private CommandDefinition(object? parameters) : this()
+        private CommandDefinition(object? parameters, CommandFlags flags) : this()
         {
             Parameters = parameters;
+            Flags = flags;
             CommandText = "";
         }
 

--- a/Dapper/SqlMapper.Async.cs
+++ b/Dapper/SqlMapper.Async.cs
@@ -939,7 +939,7 @@ namespace Dapper
                 using var cmd = command.TrySetupAsyncCommand(cnn, info.ParamReader);
                 using var reader = await ExecuteReaderWithFlagsFallbackAsync(cmd, wasClosed, CommandBehavior.SequentialAccess | CommandBehavior.SingleResult, command.CancellationToken).ConfigureAwait(false);
                 if (!command.Buffered) wasClosed = false; // handing back open reader; rely on command-behavior
-                var results = MultiMapImpl<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(null, CommandDefinition.ForCallback(command.Parameters), map, splitOn, reader, identity, true);
+                var results = MultiMapImpl<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(null, CommandDefinition.ForCallback(command.Parameters, command.Flags), map, splitOn, reader, identity, true);
                 return command.Buffered ? results.ToList() : results;
             }
             finally

--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -1658,7 +1658,7 @@ namespace Dapper
                     var deserializers = GenerateDeserializers(identity, splitOn, reader);
                     deserializer = cinfo.Deserializer = new DeserializerState(hash, deserializers[0]);
                     otherDeserializers = cinfo.OtherDeserializers = deserializers.Skip(1).ToArray();
-                    SetQueryCache(identity, cinfo);
+                    if (command.AddToCache) SetQueryCache(identity, cinfo);
                 }
 
                 Func<DbDataReader, TReturn> mapIt = GenerateMapper(types.Length, deserializer.Func, otherDeserializers, map);

--- a/tests/Dapper.Tests/AsyncTests.cs
+++ b/tests/Dapper.Tests/AsyncTests.cs
@@ -995,5 +995,41 @@ SET @AddressPersonId = @PersonId", p).ConfigureAwait(false))
             Assert.Equal(123, c);
             Assert.Equal(456, d);
         }
+
+       [Fact]
+        public async Task AssertNoCacheWorksForMultiMap()
+        {
+            const int a = 123, b = 456;
+            var cmdDef = new CommandDefinition("select @a as a, @b as b;", new
+            {
+                a,
+                b
+            }, commandType: CommandType.Text, flags: CommandFlags.NoCache | CommandFlags.Buffered);
+
+            SqlMapper.PurgeQueryCache();
+            var before = SqlMapper.GetCachedSQLCount();
+            Assert.Equal(0, before);
+
+            await MarsConnection.QueryAsync<int, int, (int, int)>(cmdDef, splitOn: "b", map: (a, b) => (a, b));
+            Assert.Equal(0, SqlMapper.GetCachedSQLCount());
+        }
+
+        [Fact]
+        public async Task AssertNoCacheWorksForQueryAsync()
+        {
+            const int a = 123, b = 456;
+            var cmdDef = new CommandDefinition("select @a as a, @b as b;", new
+            {
+                a,
+                b
+            }, commandType: CommandType.Text, flags: CommandFlags.NoCache | CommandFlags.Buffered);
+
+            SqlMapper.PurgeQueryCache();
+            var before = SqlMapper.GetCachedSQLCount();
+            Assert.Equal(0, before);
+
+            await MarsConnection.QueryAsync<(int, int)>(cmdDef);
+            Assert.Equal(0, SqlMapper.GetCachedSQLCount());    
+        }
     }
 }


### PR DESCRIPTION
We also can't use `NoCache` to work around the problems in #2117. This PR seems to make `NoCache`work for our use case. Thanks to @Dot-H for providing test cases.