### PR TITLE
CI - update pgsql to 13

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ skip_commits:
 environment:
   Appveyor: true
   # Postgres
-  POSTGRES_PATH: C:\Program Files\PostgreSQL\9.6
+  POSTGRES_PATH: C:\Program Files\PostgreSQL\13
   PGUSER: postgres
   PGPASSWORD: Password12!
   POSTGRES_ENV_POSTGRES_USER: postgres
@@ -32,7 +32,7 @@ environment:
 
 services:
   # - mysql
-  - postgresql
+  - postgresql13
 
 init:
   - git config --global core.autocrlf input


### PR DESCRIPTION
CI is seeing:

```
Starting PostgreSQL 9.6
Start-Service : Cannot find any service with service name 'postgresql-x64-9.6'.
At line:1 char:1
+ Start-Service 'postgresql-x64-9.6'
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (postgresql-x64-9.6:String) [Start-Service], ServiceCommandException
    + FullyQualifiedErrorId : NoServiceFoundForGivenName,Microsoft.PowerShell.Commands.StartServiceCommand
```

I suspect this is due to [these updates](https://www.appveyor.com/updates/2024/09/04/)

Crossref: https://github.com/DapperLib/Dapper/pull/2118

Looks good:

```
Starting PostgreSQL 13
```