### PR TITLE
Properly handle value types when setting properties on dynamic objects returned by Dapper queries

### DIFF
--- a/Dapper/SqlMapper.DapperRowMetaObject.cs
+++ b/Dapper/SqlMapper.DapperRowMetaObject.cs
@@ -81,7 +81,7 @@ namespace Dapper
                 var parameters = new System.Linq.Expressions.Expression[]
                                      {
                                          System.Linq.Expressions.Expression.Constant(binder.Name),
-                                         value.Expression,
+                                         System.Linq.Expressions.Expression.Convert(value.Expression, typeof(object)),
                                      };
 
                 var callMethod = CallMethod(setValueMethod, parameters);

--- a/tests/Dapper.Tests/MiscTests.cs
+++ b/tests/Dapper.Tests/MiscTests.cs
@@ -1358,5 +1358,41 @@ insert TPTable (Value) values (2), (568)");
 
             Assert.Single(results);
         }
+
+        [Fact]
+        public void SetDynamicProperty_WithReferenceType_Succeeds()
+        {
+            var obj = connection.QueryFirst("select 1 as ExistingProperty");
+
+            obj.ExistingProperty = "foo";
+            Assert.Equal("foo", (string)obj.ExistingProperty);
+
+            obj.NewProperty = new Uri("http://example.net/");
+            Assert.Equal(new Uri("http://example.net/"), (Uri)obj.NewProperty);
+        }
+
+        [Fact]
+        public void SetDynamicProperty_WithBoxedValueType_Succeeds()
+        {
+            var obj = connection.QueryFirst("select 'foo' as ExistingProperty");
+
+            obj.ExistingProperty = (object)1;
+            Assert.Equal(1, (int)obj.ExistingProperty);
+
+            obj.NewProperty = (object)true;
+            Assert.True(obj.NewProperty);
+        }
+
+        [Fact]
+        public void SetDynamicProperty_WithValueType_Succeeds()
+        {
+            var obj = connection.QueryFirst("select 'foo' as ExistingProperty");
+
+            obj.ExistingProperty = 1;
+            Assert.Equal(1, (int)obj.ExistingProperty);
+
+            obj.NewProperty = true;
+            Assert.True(obj.NewProperty);
+        }
     }
 }


### PR DESCRIPTION
This PR resolves an issue where assigning unboxed value types to dynamic properties in `DapperRow` objects caused an exception. The problem occurred because value types are not automatically boxed when using expression trees, resulting in errors like:

`System.ArgumentException: Expression of type 'System.Int32' cannot be used for parameter of type 'System.Object' of method 'System.Object SetValue(System.String, System.Object)'`

The fix ensures that value types are properly boxed before being assigned.

Tests have been added to validate the behavior, covering scenarios with reference types, boxed value types, and unboxed value types.

Please review and provide any feedback or suggestions. Thanks for your time and consideration!