### PR TITLE
Custom CreateCommand method. Resolves #2127

### DIFF
--- a/Dapper/PublicAPI.Shipped.txt
+++ b/Dapper/PublicAPI.Shipped.txt
@@ -9,6 +9,7 @@ Dapper.CommandDefinition.Buffered.get -> bool
 Dapper.CommandDefinition.CancellationToken.get -> System.Threading.CancellationToken
 Dapper.CommandDefinition.CommandDefinition() -> void
 Dapper.CommandDefinition.CommandDefinition(string! commandText, object? parameters = null, System.Data.IDbTransaction? transaction = null, int? commandTimeout = null, System.Data.CommandType? commandType = null, Dapper.CommandFlags flags = Dapper.CommandFlags.Buffered, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void
+Dapper.CommandDefinition.CommandDefinition(string! commandText, System.Func<System.Data.IDbConnection!, System.Data.IDbCommand!>! createCommand, object? parameters = null, System.Data.IDbTransaction? transaction = null, int? commandTimeout = null, System.Data.CommandType? commandType = null, Dapper.CommandFlags flags = Dapper.CommandFlags.Buffered, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void
 Dapper.CommandDefinition.CommandText.get -> string!
 Dapper.CommandDefinition.CommandTimeout.get -> int?
 Dapper.CommandDefinition.CommandType.get -> System.Data.CommandType?

--- a/tests/Dapper.Tests/MiscTests.cs
+++ b/tests/Dapper.Tests/MiscTests.cs
@@ -1394,5 +1394,22 @@ insert TPTable (Value) values (2), (568)");
             obj.NewProperty = true;
             Assert.True(obj.NewProperty);
         }
+
+        [Fact]
+        public void TestCreateCommandCalled()
+        {
+            var customCreateCommandCalled = false;
+            var createCommand = new Func<IDbConnection, IDbCommand>(conn =>
+            {
+                customCreateCommandCalled = true;
+                return conn.CreateCommand();
+            });
+
+            var definition = new CommandDefinition("select 1", createCommand);
+
+            connection.Query<int>(definition);
+
+            Assert.True(customCreateCommandCalled);
+        }
     }
 }


### PR DESCRIPTION
This allows the user to provide their own IDbCommand to be used by Dapper internally.