### PR TITLE
Mark AddTypeHandlerImpl as obsolete and prevent lost updates via AddTypeHandler

### DIFF
--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -266,11 +266,14 @@ namespace Dapper
         [MemberNotNull(nameof(typeHandlers))]
         private static void ResetTypeHandlers(bool clone)
         {
-            typeHandlers = [];
-            AddTypeHandlerImpl(typeof(DataTable), new DataTableHandler(), clone);
-            AddTypeHandlerImpl(typeof(XmlDocument), new XmlDocumentHandler(), clone);
-            AddTypeHandlerImpl(typeof(XDocument), new XDocumentHandler(), clone);
-            AddTypeHandlerImpl(typeof(XElement), new XElementHandler(), clone);
+            lock (typeHandlersSyncLock)
+            {
+                typeHandlers = [];
+                AddTypeHandlerCore(typeof(DataTable), new DataTableHandler(), clone);
+                AddTypeHandlerCore(typeof(XmlDocument), new XmlDocumentHandler(), clone);
+                AddTypeHandlerCore(typeof(XDocument), new XDocumentHandler(), clone);
+                AddTypeHandlerCore(typeof(XElement), new XElementHandler(), clone);
+            }
         }
 
         /// <summary>
@@ -339,7 +342,7 @@ namespace Dapper
         /// </summary>
         /// <param name="type">The type to handle.</param>
         /// <param name="handler">The handler to process the <paramref name="type"/>.</param>
-        public static void AddTypeHandler(Type type, ITypeHandler handler) => AddTypeHandlerImpl(type, handler, true);
+        public static void AddTypeHandler(Type type, ITypeHandler handler) => AddTypeHandlerCore(type, handler, true);
         /// <summary>
         /// Determine if the specified type will be processed by a custom handler.
         /// </summary>
@@ -353,7 +356,16 @@ namespace Dapper
         /// <param name="type">The type to handle.</param>
         /// <param name="handler">The handler to process the <paramref name="type"/>.</param>
         /// <param name="clone">Whether to clone the current type handler map.</param>
+        [Obsolete("Please use " + nameof(AddTypeHandler), error: true)]
+        [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
         public static void AddTypeHandlerImpl(Type type, ITypeHandler? handler, bool clone)
+        {
+            // this method was accidentally made public; we'll mark it as illegal, but
+            // preserve existing usage in compiled code; sorry about this!
+            AddTypeHandlerCore(type, handler, clone);
+        }
+
+        private static void AddTypeHandlerCore(Type type, ITypeHandler? handler, bool clone)
         {
             if (type is null) throw new ArgumentNullException(nameof(type));
 
@@ -373,29 +385,35 @@ namespace Dapper
                 }
             }
 
-            var snapshot = typeHandlers;
-            if (snapshot.TryGetValue(type, out var oldValue) && handler == oldValue) return; // nothing to do
+            // synchronize between callers mutating type-handlers; note that regular query
+            // code may still be accessing the field, so we still use snapshot/mutate/swap;
+            // the synchronize is just to prevent lost writes
+            lock (typeHandlersSyncLock)
+            {
+                var snapshot = typeHandlers;
+                if (snapshot.TryGetValue(type, out var oldValue) && handler == oldValue) return; // nothing to do
 
-            var newCopy = clone ? new Dictionary<Type, ITypeHandler>(snapshot) : snapshot;
+                var newCopy = clone ? new Dictionary<Type, ITypeHandler>(snapshot) : snapshot;
 
 #pragma warning disable 618
-            typeof(TypeHandlerCache<>).MakeGenericType(type).GetMethod(nameof(TypeHandlerCache<int>.SetHandler), BindingFlags.Static | BindingFlags.NonPublic)!.Invoke(null, [handler]);
-            if (secondary is not null)
-            {
-                typeof(TypeHandlerCache<>).MakeGenericType(secondary).GetMethod(nameof(TypeHandlerCache<int>.SetHandler), BindingFlags.Static | BindingFlags.NonPublic)!.Invoke(null, [handler]);
-            }
+                typeof(TypeHandlerCache<>).MakeGenericType(type).GetMethod(nameof(TypeHandlerCache<int>.SetHandler), BindingFlags.Static | BindingFlags.NonPublic)!.Invoke(null, [handler]);
+                if (secondary is not null)
+                {
+                    typeof(TypeHandlerCache<>).MakeGenericType(secondary).GetMethod(nameof(TypeHandlerCache<int>.SetHandler), BindingFlags.Static | BindingFlags.NonPublic)!.Invoke(null, [handler]);
+                }
 #pragma warning restore 618
-            if (handler is null)
-            {
-                newCopy.Remove(type);
-                if (secondary is not null) newCopy.Remove(secondary);
+                if (handler is null)
+                {
+                    newCopy.Remove(type);
+                    if (secondary is not null) newCopy.Remove(secondary);
+                }
+                else
+                {
+                    newCopy[type] = handler;
+                    if (secondary is not null) newCopy[secondary] = handler;
+                }
+                typeHandlers = newCopy;
             }
-            else
-            {
-                newCopy[type] = handler;
-                if (secondary is not null) newCopy[secondary] = handler;
-            }
-            typeHandlers = newCopy;
         }
 
         /// <summary>
@@ -403,9 +421,10 @@ namespace Dapper
         /// </summary>
         /// <typeparam name="T">The type to handle.</typeparam>
         /// <param name="handler">The handler for the type <typeparamref name="T"/>.</param>
-        public static void AddTypeHandler<T>(TypeHandler<T> handler) => AddTypeHandlerImpl(typeof(T), handler, true);
+        public static void AddTypeHandler<T>(TypeHandler<T> handler) => AddTypeHandlerCore(typeof(T), handler, true);
 
         private static Dictionary<Type, ITypeHandler> typeHandlers;
+        private static readonly object typeHandlersSyncLock = new();
 
         internal const string LinqBinary = "System.Data.Linq.Binary";
 
@@ -479,7 +498,7 @@ namespace Dapper
                         {
                             handler = (ITypeHandler)Activator.CreateInstance(
                                 typeof(SqlDataRecordHandler<>).MakeGenericType(argTypes))!;
-                            AddTypeHandlerImpl(type, handler, true);
+                            AddTypeHandlerCore(type, handler, true);
                             return DbType.Object;
                         }
                         catch

--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -390,10 +390,9 @@ namespace Dapper
             // the synchronize is just to prevent lost writes
             lock (typeHandlersSyncLock)
             {
-                var snapshot = typeHandlers;
-                if (snapshot.TryGetValue(type, out var oldValue) && handler == oldValue) return; // nothing to do
+                if (typeHandlers.TryGetValue(type, out var oldValue) && handler == oldValue) return; // nothing to do
 
-                var newCopy = clone ? new Dictionary<Type, ITypeHandler>(snapshot) : snapshot;
+                var newCopy = clone ? new Dictionary<Type, ITypeHandler>(typeHandlers) : typeHandlers;
 
 #pragma warning disable 618
                 typeof(TypeHandlerCache<>).MakeGenericType(type).GetMethod(nameof(TypeHandlerCache<int>.SetHandler), BindingFlags.Static | BindingFlags.NonPublic)!.Invoke(null, [handler]);

--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -362,7 +362,7 @@ namespace Dapper
         {
             // this method was accidentally made public; we'll mark it as illegal, but
             // preserve existing usage in compiled code; sorry about this!
-            AddTypeHandlerCore(type, handler, clone);
+            AddTypeHandlerCore(type, handler, true); // do not allow suppress clone
         }
 
         private static void AddTypeHandlerCore(Type type, ITypeHandler? handler, bool clone)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ stack: postgresql 15
 environment:
   Appveyor: true
   # Postgres
-  POSTGRES_PATH: C:\Program Files\PostgreSQL\15.8
+  POSTGRES_PATH: C:\Program Files\PostgreSQL\15
   PGUSER: postgres
   PGPASSWORD: Password12!
   POSTGRES_ENV_POSTGRES_USER: postgres

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ skip_commits:
 environment:
   Appveyor: true
   # Postgres
-  POSTGRES_PATH: C:\Program Files\PostgreSQL\13
+  POSTGRES_PATH: C:\Program Files\PostgreSQL\9.6
   PGUSER: postgres
   PGPASSWORD: Password12!
   POSTGRES_ENV_POSTGRES_USER: postgres
@@ -32,7 +32,7 @@ environment:
 
 services:
   # - mysql
-  - postgresql13
+  - postgresql
 
 init:
   - git config --global core.autocrlf input

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,10 +9,12 @@ skip_commits:
 # install:
 #   - choco install dotnet-sdk --version 8.0.100
 
+stack: postgresql 15
+
 environment:
   Appveyor: true
   # Postgres
-  POSTGRES_PATH: C:\Program Files\PostgreSQL\9.6
+  POSTGRES_PATH: C:\Program Files\PostgreSQL\15.8
   PGUSER: postgres
   PGPASSWORD: Password12!
   POSTGRES_ENV_POSTGRES_USER: postgres
@@ -32,7 +34,7 @@ environment:
 
 services:
   # - mysql
-  - postgresql96
+  - postgresql15
 
 init:
   - git config --global core.autocrlf input

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ environment:
 
 services:
   # - mysql
-  - postgresql
+  - postgresql96
 
 init:
   - git config --global core.autocrlf input


### PR DESCRIPTION
`AddTypeHandlerImpl` was never intended to be `public`; oops

also drive-by fix to prevent lost updates via AddTypeHandler

- mark AddTypeHandlerImpl as obsolete
- syncronize type-handler mutates, to prevent lost writes

fix #1815

alternate to #2107