### PR TITLE
CI: use preinstalled sdk

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,9 +6,6 @@ skip_commits:
   files:
     - '**/*.md'
 
-install:
-  - choco install dotnet-sdk --version 9.0.101
-
 environment:
   Appveyor: true
   # Postgres


### PR DESCRIPTION
Problem:

```
Packages requiring reboot:
 - vcredist140 (exit code 3010)
The recent package changes indicate a reboot is necessary.
 Please reboot at your earliest convenience.
Command exited with code 3010
```

Same as https://github.com/DapperLib/Dapper/pull/2042.
Instead of explicitly installing the .NET SDK, this change uses the SDK preinstalled in the image.

The relevant line was originally added in the following PR to use .NET 9.0:
https://github.com/DapperLib/Dapper/commit/bd4f75b512de3e00f2c2631d5309961a1ecfea23#diff-92ab9a36df5d8e9f7076f2fdec59492d1ac2d9cf27ea046767a7fc4d542ef3dc

On December 22, 2024, AppVeyor updated the Visual Studio 2022 image, and the included .NET SDK was upgraded to 9.0.101:
https://www.appveyor.com/updates/2024/12/22/

Therefore, these lines is no longer necessary.