### PR TITLE
CI: serialize DB-dependent tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
     - name: .NET Build
       run: dotnet build Build.csproj -c Release /p:CI=true
     - name: Dapper Tests
-      run: dotnet test tests/Dapper.Tests/Dapper.Tests.csproj -c Release --logger GitHubActions /p:CI=true
+      run: dotnet test tests/Dapper.Tests/Dapper.Tests.csproj -c Release --logger GitHubActions -p:CI=true -p:TestTfmsInParallel=false
       env:
         MySqlConnectionString: Server=localhost;Port=${{ job.services.mysql.ports[3306] }};Uid=root;Pwd=root;Database=test;Allow User Variables=true
         OLEDBConnectionString: Provider=SQLOLEDB;Server=tcp:localhost,${{ job.services.sqlserver.ports[1433] }};Database=tempdb;User Id=sa;Password=Password.;

--- a/build.ps1
+++ b/build.ps1
@@ -22,8 +22,8 @@ dotnet build ".\Build.csproj" -c Release /p:CI=true
 Write-Host "Done building." -ForegroundColor "Green"
 
 if ($RunTests) {
-    Write-Host "Running tests: Build.csproj traversal (all frameworks)" -ForegroundColor "Magenta"
-    dotnet test ".\Build.csproj" -c Release --no-build
+    Write-Host "Running tests: Build.csproj" -ForegroundColor "Magenta"
+    dotnet test ".\Build.csproj" -c Release --no-build -p:TestTfmsInParallel=false
     if ($LastExitCode -ne 0) {
         Write-Host "Error with tests, aborting build." -Foreground "Red"
         Exit 1


### PR DESCRIPTION
## Problem
Automated tests for the main branch are intermittently failing (though they sometimes succeed).
See: https://ci.appveyor.com/project/StackExchange/dapper

Example: 
```
  Failed SystemSqlClientParameterTests.TestTVPWithAnonymousEmptyObject [33 ms]
  Error Message:
   System.Data.SqlClient.SqlException : Could not find the type 'int_list_type'. Either it does not exist or you do not have the necessary permission.
```

## Cause

This is likely due to database-dependent tests being executed in parallel.

On December 22, 2024, AppVeyor updated their build image, which now includes the .NET 9 SDK:
https://www.appveyor.com/updates/2024/12/22/

Since Dapper targets multiple frameworks, this update caused tests to start running in parallel by default.

> For multi-targeted projects, tests are run for each targeted framework. The test host and the unit test framework are packaged as NuGet packages and are restored as ordinary dependencies for the project. Starting with the .NET 9 SDK, these tests are run in parallel by default.

https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-test?tabs=dotnet-test-with-vstest#description-1

## Solution

Following the official documentation, disable parallel execution of tests across TargetFrameworks.

> To disable parallel execution, set the TestTfmsInParallel MSBuild property to false.