### PR TITLE
This PR addresses issue #1573 by modifying the GetDeserializer logic to map nullable decimal values to 0m instead of null.

### DIFF
--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -1973,6 +1973,11 @@ namespace Dapper
                 }
                 return GetTypeDeserializer(type, reader, startBound, length, returnNullIfFirstMissing);
             }
+            //  Patch for nullable decimal issue
+            if (type == typeof(decimal?))
+            {
+                return r => r.IsDBNull(startBound) ? (object)0m : r.GetDecimal(startBound);
+            }
             return GetSimpleValueDeserializer(type, underlyingType ?? type, startBound, useGetFieldValue);
         }
 


### PR DESCRIPTION
- Added explicit check for `decimal?` types in GetDeserializer
- Returns 0m when encountering a NULL value
- Maintains existing behavior for other types

Closes #1573