### PR TITLE
Use custom collector to avoid intermediate array allocations

### DIFF
--- a/Dapper.StrongName/Dapper.StrongName.csproj
+++ b/Dapper.StrongName/Dapper.StrongName.csproj
@@ -19,10 +19,12 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461'">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
+    <PackageReference Include="System.Memory" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" />
+    <PackageReference Include="System.Memory" />
   </ItemGroup>
 </Project>

--- a/Dapper/CollectorT.cs
+++ b/Dapper/CollectorT.cs
@@ -1,0 +1,149 @@
+﻿using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Runtime.CompilerServices;
+
+namespace Dapper;
+
+/// <summary>
+/// Allows efficient collection of data into lists, arrays, etc.
+/// </summary>
+/// <remarks>This is a mutable struct; treat with caution.</remarks>
+/// <typeparam name="T"></typeparam>
+[DebuggerDisplay($"{{{nameof(ToString)}(),nq}}")]
+[SuppressMessage("Usage", "CA2231:Overload operator equals on overriding value type Equals", Justification = "Equality not supported")]
+public struct Collector<T>
+{
+    /// <summary>
+    /// Create a new collector using a size hint for the number of elements expected.
+    /// </summary>
+    public Collector(int capacityHint)
+    {
+        oversized = capacityHint > 0 ? ArrayPool<T>.Shared.Rent(capacityHint) : [];
+        capacity = oversized.Length;
+    }
+
+    /// <inheritdoc/>
+    public readonly override string ToString() => $"Count: {count}";
+
+    /// <inheritdoc/>
+    [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
+    public readonly override bool Equals([NotNullWhen(true)] object? obj) => throw new NotSupportedException();
+
+    /// <inheritdoc/>
+    [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
+    public readonly override int GetHashCode() => throw new NotSupportedException();
+
+    private T[] oversized;
+    private int count, capacity;
+
+    /// <summary>
+    /// Gets the current capacity of the backing buffer of this instance.
+    /// </summary>
+    internal readonly int Capacity => capacity;
+
+    /// <summary>
+    /// Gets the number of elements represented by this instance.
+    /// </summary>
+    public readonly int Count => count;
+
+    /// <summary>
+    /// Gets the underlying elements represented by this instance.
+    /// </summary>
+    public readonly Span<T> Span => new(oversized, 0, count);
+
+    /// <summary>
+    /// Gets the underlying elements represented by this instance.
+    /// </summary>
+    public readonly ArraySegment<T> ArraySegment => new(oversized, 0, count);
+
+    /// <summary>
+    /// Gets the element at the specified index.
+    /// </summary>
+    public readonly ref T this[int index]
+    {
+        get
+        {
+            return ref index >= 0 & index < count ? ref oversized[index] : ref OutOfRange();
+
+            static ref T OutOfRange() => throw new ArgumentOutOfRangeException(nameof(index));
+        }
+    }
+
+    /// <summary>
+    /// Add an element to the collection.
+    /// </summary>
+    public void Add(T value)
+    {
+        if (capacity == count) Expand();
+        oversized[count++] = value;
+    }
+
+    /// <summary>
+    /// Add elements to the collection.
+    /// </summary>
+    public void AddRange(ReadOnlySpan<T> values)
+    {
+        EnsureCapacity(count + values.Length);
+        values.CopyTo(new(oversized, count, values.Length));
+        count += values.Length;
+    }
+
+    private void EnsureCapacity(int minCapacity)
+    {
+        if (capacity < minCapacity)
+        {
+            var newBuffer = ArrayPool<T>.Shared.Rent(minCapacity);
+            Span.CopyTo(newBuffer);
+            var oldBuffer = oversized;
+            oversized = newBuffer;
+            capacity = newBuffer.Length;
+
+            if (oldBuffer is not null)
+            {
+                ArrayPool<T>.Shared.Return(oldBuffer);
+            }
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void Expand() => EnsureCapacity(Math.Max(capacity * 2, 16));
+
+    /// <summary>
+    /// Release any resources associated with this instance.
+    /// </summary>
+    public void Clear()
+    {
+        count = 0;
+        if (capacity != 0)
+        {
+            capacity = 0;
+            ArrayPool<T>.Shared.Return(oversized);
+            oversized = [];
+        }
+    }
+
+    /// <summary>
+    /// Create an array with the elements associated with this instance, and release any resources.
+    /// </summary>
+    public T[] ToArrayAndClear()
+    {
+        T[] result = [.. Span]; // let the compiler worry about the per-platform implementation
+        Clear();
+        return result;
+    }
+
+    /// <summary>
+    /// Create an array with the elements associated with this instance, and release any resources.
+    /// </summary>
+    public List<T> ToListAndClear()
+    {
+        List<T> result = [.. Span]; // let the compiler worry about the per-platform implementation (net8+ in particular)
+        Clear();
+        return result;
+    }
+}

--- a/Dapper/Dapper.csproj
+++ b/Dapper/Dapper.csproj
@@ -26,10 +26,12 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461'">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
+    <PackageReference Include="System.Memory" />
   </ItemGroup>
   
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" />
+    <PackageReference Include="System.Memory" />
   </ItemGroup>
 </Project>

--- a/Dapper/DefaultTypeMap.cs
+++ b/Dapper/DefaultTypeMap.cs
@@ -51,12 +51,12 @@ namespace Dapper
             return t
                   .GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
                   .Where(p => GetPropertySetter(p, t) is not null)
-                  .ToList();
+                  .AsList();
         }
 
         internal static List<FieldInfo> GetSettableFields(Type t)
         {
-            return t.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance).ToList();
+            return t.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance).AsList();
         }
 
         /// <summary>
@@ -115,7 +115,7 @@ namespace Dapper
         public ConstructorInfo? FindExplicitConstructor()
         {
             var constructors = _type.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-            var withAttr = constructors.Where(c => c.GetCustomAttributes(typeof(ExplicitConstructorAttribute), true).Length > 0).ToList();
+            var withAttr = constructors.Where(c => c.GetCustomAttributes(typeof(ExplicitConstructorAttribute), true).Length > 0).AsList();
 
             if (withAttr.Count == 1)
             {

--- a/Dapper/PublicAPI.Shipped.txt
+++ b/Dapper/PublicAPI.Shipped.txt
@@ -177,6 +177,7 @@ static Dapper.SqlMapper.AddTypeHandlerImpl(System.Type! type, Dapper.SqlMapper.I
 static Dapper.SqlMapper.AddTypeMap(System.Type! type, System.Data.DbType dbType) -> void
 static Dapper.SqlMapper.AddTypeMap(System.Type! type, System.Data.DbType dbType, bool useGetFieldValue) -> void
 static Dapper.SqlMapper.AsList<T>(this System.Collections.Generic.IEnumerable<T>? source) -> System.Collections.Generic.List<T>!
+static Dapper.SqlMapper.AsListAsync<T>(this System.Collections.Generic.IAsyncEnumerable<T>? source, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.List<T>!>!
 static Dapper.SqlMapper.AsTableValuedParameter(this System.Data.DataTable! table, string? typeName = null) -> Dapper.SqlMapper.ICustomQueryParameter!
 static Dapper.SqlMapper.AsTableValuedParameter<T>(this System.Collections.Generic.IEnumerable<T>! list, string? typeName = null) -> Dapper.SqlMapper.ICustomQueryParameter!
 static Dapper.SqlMapper.ConnectionStringComparer.get -> System.Collections.Generic.IEqualityComparer<string!>!
@@ -333,3 +334,19 @@ static Dapper.SqlMapper.ThrowNullCustomQueryParameter(string! name) -> void
 static Dapper.SqlMapper.TypeHandlerCache<T>.Parse(object! value) -> T?
 static Dapper.SqlMapper.TypeHandlerCache<T>.SetValue(System.Data.IDbDataParameter! parameter, object! value) -> void
 static Dapper.SqlMapper.TypeMapProvider -> System.Func<System.Type!, Dapper.SqlMapper.ITypeMap!>!
+
+Dapper.Collector<T>
+Dapper.Collector<T>.Collector() -> void
+Dapper.Collector<T>.Collector(int capacityHint) -> void
+Dapper.Collector<T>.Count.get -> int
+Dapper.Collector<T>.Span.get -> System.Span<T>
+Dapper.Collector<T>.ArraySegment.get -> System.ArraySegment<T>
+Dapper.Collector<T>.Clear() -> void
+Dapper.Collector<T>.Add(T value) -> void
+Dapper.Collector<T>.AddRange(System.ReadOnlySpan<T> values) -> void
+Dapper.Collector<T>.ToListAndClear() -> System.Collections.Generic.List<T>!
+Dapper.Collector<T>.ToArrayAndClear() -> T[]!
+Dapper.Collector<T>.this[int index].get -> T
+override Dapper.Collector<T>.ToString() -> string!
+override Dapper.Collector<T>.GetHashCode() -> int
+override Dapper.Collector<T>.Equals(object? obj) -> bool

--- a/Dapper/SqlMapper.GridReader.Async.cs
+++ b/Dapper/SqlMapper.GridReader.Async.cs
@@ -229,12 +229,12 @@ namespace Dapper
             {
                 try
                 {
-                    var buffer = new List<T>();
+                    var buffer = new Collector<T>();
                     while (index == ResultIndex && await reader!.ReadAsync(cancel).ConfigureAwait(false))
                     {
                         buffer.Add(ConvertTo<T>(deserializer(reader)));
                     }
-                    return buffer;
+                    return buffer.ToListAndClear();
                 }
                 finally // finally so that First etc progresses things even when multiple rows
                 {

--- a/Dapper/SqlMapper.GridReader.cs
+++ b/Dapper/SqlMapper.GridReader.cs
@@ -202,7 +202,7 @@ namespace Dapper
                     cache.Deserializer = deserializer;
                 }
                 var result = ReadDeferred<T>(index, deserializer.Func, type);
-                return buffered ? result.ToList() : result;
+                return buffered ? result.AsList() : result;
             }
 
             private T ReadRow<T>(Type type, Row row)
@@ -283,7 +283,7 @@ namespace Dapper
             public IEnumerable<TReturn> Read<TFirst, TSecond, TReturn>(Func<TFirst, TSecond, TReturn> func, string splitOn = "id", bool buffered = true)
             {
                 var result = MultiReadInternal<TFirst, TSecond, DontMap, DontMap, DontMap, DontMap, DontMap, TReturn>(func, splitOn);
-                return buffered ? result.ToList() : result;
+                return buffered ? result.AsList() : result;
             }
 
             /// <summary>
@@ -299,7 +299,7 @@ namespace Dapper
             public IEnumerable<TReturn> Read<TFirst, TSecond, TThird, TReturn>(Func<TFirst, TSecond, TThird, TReturn> func, string splitOn = "id", bool buffered = true)
             {
                 var result = MultiReadInternal<TFirst, TSecond, TThird, DontMap, DontMap, DontMap, DontMap, TReturn>(func, splitOn);
-                return buffered ? result.ToList() : result;
+                return buffered ? result.AsList() : result;
             }
 
             /// <summary>
@@ -316,7 +316,7 @@ namespace Dapper
             public IEnumerable<TReturn> Read<TFirst, TSecond, TThird, TFourth, TReturn>(Func<TFirst, TSecond, TThird, TFourth, TReturn> func, string splitOn = "id", bool buffered = true)
             {
                 var result = MultiReadInternal<TFirst, TSecond, TThird, TFourth, DontMap, DontMap, DontMap, TReturn>(func, splitOn);
-                return buffered ? result.ToList() : result;
+                return buffered ? result.AsList() : result;
             }
 
             /// <summary>
@@ -334,7 +334,7 @@ namespace Dapper
             public IEnumerable<TReturn> Read<TFirst, TSecond, TThird, TFourth, TFifth, TReturn>(Func<TFirst, TSecond, TThird, TFourth, TFifth, TReturn> func, string splitOn = "id", bool buffered = true)
             {
                 var result = MultiReadInternal<TFirst, TSecond, TThird, TFourth, TFifth, DontMap, DontMap, TReturn>(func, splitOn);
-                return buffered ? result.ToList() : result;
+                return buffered ? result.AsList() : result;
             }
 
             /// <summary>
@@ -353,7 +353,7 @@ namespace Dapper
             public IEnumerable<TReturn> Read<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TReturn>(Func<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TReturn> func, string splitOn = "id", bool buffered = true)
             {
                 var result = MultiReadInternal<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, DontMap, TReturn>(func, splitOn);
-                return buffered ? result.ToList() : result;
+                return buffered ? result.AsList() : result;
             }
 
             /// <summary>
@@ -373,7 +373,7 @@ namespace Dapper
             public IEnumerable<TReturn> Read<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(Func<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn> func, string splitOn = "id", bool buffered = true)
             {
                 var result = MultiReadInternal<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(func, splitOn);
-                return buffered ? result.ToList() : result;
+                return buffered ? result.AsList() : result;
             }
 
             /// <summary>
@@ -387,7 +387,7 @@ namespace Dapper
             public IEnumerable<TReturn> Read<TReturn>(Type[] types, Func<object[], TReturn> map, string splitOn = "id", bool buffered = true)
             {
                 var result = MultiReadInternal(types, map, splitOn);
-                return buffered ? result.ToList() : result;
+                return buffered ? result.AsList() : result;
             }
 
             private IEnumerable<T> ReadDeferred<T>(int index, Func<DbDataReader, object> deserializer, Type effectiveType)

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,34 +8,36 @@
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Microsoft.SqlServer.Types" Version="14.0.1016.290" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.7.115" />
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.1" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.5" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="4.14.0" />
+    <PackageVersion Include="System.Memory" Version="4.6.3" />
     <PackageVersion Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
+
     <!-- tests -->
-    <PackageVersion Include="Azure.Identity" Version="1.13.2" />
+    <PackageVersion Include="Azure.Identity" Version="1.14.0" />
     <PackageVersion Include="Belgrade.Sql.Client" Version="1.1.4" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
     <PackageVersion Include="Dashing" Version="2.10.1" />
     <PackageVersion Include="Dapper.Contrib" Version="2.0.78" />
-    <PackageVersion Include="DuckDB.NET.Data.Full" Version="1.1.3" />
-    <PackageVersion Include="DevExpress.Xpo" Version="24.2.3" />
-    <PackageVersion Include="FirebirdSql.Data.FirebirdClient" Version="10.3.2" />
+    <PackageVersion Include="DuckDB.NET.Data.Full" Version="1.2.1" />
+    <PackageVersion Include="DevExpress.Xpo" Version="24.2.7" />
+    <PackageVersion Include="FirebirdSql.Data.FirebirdClient" Version="10.3.3" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageVersion Include="Iesi.Collections" Version="4.1.1" />
     <PackageVersion Include="linq2db.SqlServer" Version="5.4.1" />
-    <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.0.1" />
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="9.0.1" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.1" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.0.2" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="9.0.5" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.5" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="Mighty" Version="3.3.0" />
     <PackageVersion Include="MySqlConnector" Version="2.4.0" />
     <PackageVersion Include="NHibernate" Version="5.5.2" />
     <PackageVersion Include="Norm.net" Version="5.4.0" />
-    <PackageVersion Include="Npgsql" Version="9.0.2" />
+    <PackageVersion Include="Npgsql" Version="9.0.3" />
     <PackageVersion Include="PetaPoco" Version="5.1.306" />
     <PackageVersion Include="RepoDb.SqlServer" Version="1.13.1" />
-    <PackageVersion Include="ServiceStack.OrmLite.SqlServer" Version="8.5.2" />
-    <PackageVersion Include="Snowflake.Data" Version="4.3.0" />
+    <PackageVersion Include="ServiceStack.OrmLite.SqlServer" Version="8.8.0" />
+    <PackageVersion Include="Snowflake.Data" Version="4.5.0" />
     <PackageVersion Include="SqlMarshal" Version="0.5.0" />
     <PackageVersion Include="SubSonic" Version="3.0.0.4" />
     <PackageVersion Include="Susanoo.SqlServer" Version="1.2.4.2" />
@@ -43,10 +45,10 @@
     <PackageVersion Include="System.Data.SQLite" Version="1.0.119" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
-    <PackageVersion Include="System.Reflection.Metadata" Version="9.0.1" />
+    <PackageVersion Include="System.Reflection.Metadata" Version="9.0.5" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
+    <PackageVersion Include="System.ValueTuple" Version="4.6.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.1" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.0" />
   </ItemGroup>
 </Project>

--- a/benchmarks/Dapper.Tests.Performance/Dapper.Tests.Performance.csproj
+++ b/benchmarks/Dapper.Tests.Performance/Dapper.Tests.Performance.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-    <PackageReference Include="Npgsql" VersionOverride="8.0.6"/>
+    <PackageReference Include="Npgsql" VersionOverride="8.0.7"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Context #2166

`List<T>` uses initial-size plus doubling, which means that for large result sets you can get multiple arrays, for example for 90 rows you might have arrays with sizes 16, 32, 64, and 128 for 90, with the final result list using the oversized 128-element array, with 90 elements.

This change uses a custom collector for this part - same logic, but it uses the array-pool so that those intermediate arrays are recycled, and the final array is right-sized, i.e. a list with count 90 and capacity 90, and all intermediate arrays reused.