### PR TITLE
Avoid double-enumerating IEnumerable<T> in AsTableValuedParameter

### DIFF
--- a/Dapper/SqlDataRecordListTVPParameter.cs
+++ b/Dapper/SqlDataRecordListTVPParameter.cs
@@ -2,7 +2,6 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Data;
-using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 
@@ -37,7 +36,15 @@ namespace Dapper
 
         internal static void Set(IDbDataParameter parameter, IEnumerable<T>? data, string? typeName)
         {
-            parameter.Value = data is not null && data.Any() ? data : null;
+            // don't enumerate "data" here - it may be a single-pass source (an open reader, a
+            // streaming iterator, etc); only short-circuit to null when we can tell for free
+            // that it is empty, since providers reject an empty TVP enumerable
+            parameter.Value = data switch
+            {
+                null => null,
+                IReadOnlyCollection<T> { Count: 0 } => null,
+                _ => data,
+            };
             StructuredHelper.ConfigureTVP(parameter, typeName);
         }
     }

--- a/tests/Dapper.Tests/ParameterTests.cs
+++ b/tests/Dapper.Tests/ParameterTests.cs
@@ -131,6 +131,25 @@ namespace Dapper.Tests
             return number_list;
         }
 
+        // wraps a sequence to prove it is only ever enumerated once, guarding against
+        // https://github.com/DapperLib/Dapper/issues/2064
+        private class SingleEnumerationEnumerable<T> : IEnumerable<T>
+        {
+            private readonly IEnumerable<T> data;
+
+            public SingleEnumerationEnumerable(IEnumerable<T> data) => this.data = data;
+
+            public bool WasEnumerated { get; private set; }
+
+            public IEnumerator<T> GetEnumerator()
+            {
+                Assert.False(WasEnumerated, "Source was enumerated more than once.");
+                WasEnumerated = true;
+                return data.GetEnumerator();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
 
         private class IntDynamicParam : SqlMapper.IDynamicParameters
         {
@@ -484,6 +503,54 @@ namespace Dapper.Tests
                     connection.Execute("DROP TYPE int_list_type");
                 }
             }
+        }
+
+        [Fact]
+        public void TestSqlDataRecordListParametersWithAsTableValuedParameterSinglePassSource()
+        {
+            try
+            {
+                connection.Execute("CREATE TYPE int_list_type AS TABLE (n int NOT NULL PRIMARY KEY)");
+                connection.Execute("CREATE PROC get_ints @integers int_list_type READONLY AS select * from @integers");
+
+                var records = new SingleEnumerationEnumerable<IDataRecord>(CreateSqlDataRecordList(connection, new int[] { 1, 2, 3 }));
+
+                var nums = connection.Query<int>("get_ints", new { integers = records.AsTableValuedParameter() }, commandType: CommandType.StoredProcedure).ToList();
+                Assert.Equal(new int[] { 1, 2, 3 }, nums);
+            }
+            finally
+            {
+                try
+                {
+                    connection.Execute("DROP PROC get_ints");
+                }
+                finally
+                {
+                    connection.Execute("DROP TYPE int_list_type");
+                }
+            }
+        }
+
+        [Fact]
+        public void AsTableValuedParameterDoesNotEnumerateNonCollectionSource()
+        {
+            var records = new SingleEnumerationEnumerable<IDataRecord>(Enumerable.Empty<IDataRecord>());
+            var parameter = new Microsoft.Data.SqlClient.SqlParameter();
+
+            SqlDataRecordListTVPParameter<IDataRecord>.Set(parameter, records, "int_list_type");
+
+            Assert.False(records.WasEnumerated);
+            Assert.Same(records, parameter.Value);
+        }
+
+        [Fact]
+        public void AsTableValuedParameterNullsOutEmptyCollectionSource()
+        {
+            var parameter = new Microsoft.Data.SqlClient.SqlParameter();
+
+            SqlDataRecordListTVPParameter<IDataRecord>.Set(parameter, Array.Empty<IDataRecord>(), "int_list_type");
+
+            Assert.Null(parameter.Value);
         }
 
         [Fact]

--- a/tests/Dapper.Tests/ParameterTests.cs
+++ b/tests/Dapper.Tests/ParameterTests.cs
@@ -535,7 +535,7 @@ namespace Dapper.Tests
         public void AsTableValuedParameterDoesNotEnumerateNonCollectionSource()
         {
             var records = new SingleEnumerationEnumerable<IDataRecord>(Enumerable.Empty<IDataRecord>());
-            var parameter = new Microsoft.Data.SqlClient.SqlParameter();
+            var parameter = Provider.CreateRawParameter("integers", DBNull.Value);
 
             SqlDataRecordListTVPParameter<IDataRecord>.Set(parameter, records, "int_list_type");
 
@@ -546,7 +546,7 @@ namespace Dapper.Tests
         [Fact]
         public void AsTableValuedParameterNullsOutEmptyCollectionSource()
         {
-            var parameter = new Microsoft.Data.SqlClient.SqlParameter();
+            var parameter = Provider.CreateRawParameter("integers", DBNull.Value);
 
             SqlDataRecordListTVPParameter<IDataRecord>.Set(parameter, Array.Empty<IDataRecord>(), "int_list_type");
 

--- a/tests/Dapper.Tests/ParameterTests.cs
+++ b/tests/Dapper.Tests/ParameterTests.cs
@@ -513,9 +513,35 @@ namespace Dapper.Tests
                 connection.Execute("CREATE TYPE int_list_type AS TABLE (n int NOT NULL PRIMARY KEY)");
                 connection.Execute("CREATE PROC get_ints @integers int_list_type READONLY AS select * from @integers");
 
-                var records = new SingleEnumerationEnumerable<IDataRecord>(CreateSqlDataRecordList(connection, new int[] { 1, 2, 3 }));
+                // SingleEnumerationEnumerable<T> has to be instantiated against the provider's
+                // concrete SqlDataRecord type here, not the shared IDataRecord interface. SqlClient
+                // recognizes a structured/TVP parameter value via a hard "value is
+                // IEnumerable<SqlDataRecord>" check (see SqlParameter.CoerceValue); that check
+                // inspects the object's actual runtime interface implementations, and generic
+                // interface implementations aren't covariant the way assignments are, so a wrapper
+                // built as IEnumerable<IDataRecord> never satisfies it, even though every element it
+                // yields really is a SqlDataRecord. Wrapping the provider-specific list directly
+                // (matching the pattern already used in TestSqlDataRecordListParametersWithTypeHandlers
+                // below) keeps that concrete typing intact while still proving single enumeration.
+                SqlMapper.ICustomQueryParameter tvp;
+#pragma warning disable CS0618 // Type or member is obsolete
+                if (connection is System.Data.SqlClient.SqlConnection)
+                {
+                    var records = new SingleEnumerationEnumerable<Microsoft.SqlServer.Server.SqlDataRecord>(CreateSqlDataRecordList_SD(new int[] { 1, 2, 3 }));
+                    tvp = records.AsTableValuedParameter();
+                }
+#pragma warning restore CS0618 // Type or member is obsolete
+                else if (connection is Microsoft.Data.SqlClient.SqlConnection)
+                {
+                    var records = new SingleEnumerationEnumerable<Microsoft.Data.SqlClient.Server.SqlDataRecord>(CreateSqlDataRecordList_MD(new int[] { 1, 2, 3 }));
+                    tvp = records.AsTableValuedParameter();
+                }
+                else
+                {
+                    throw new ArgumentException(nameof(connection));
+                }
 
-                var nums = connection.Query<int>("get_ints", new { integers = records.AsTableValuedParameter() }, commandType: CommandType.StoredProcedure).ToList();
+                var nums = connection.Query<int>("get_ints", new { integers = tvp }, commandType: CommandType.StoredProcedure).ToList();
                 Assert.Equal(new int[] { 1, 2, 3 }, nums);
             }
             finally


### PR DESCRIPTION
`SqlDataRecordListTVPParameter<T>.Set` used `data.Any()` to swap an empty sequence for `null`, which forced an extra enumeration of the source before the caller ever executed the command. For single-pass sources (open readers, streaming iterators, etc.) that meant the real enumeration during command execution either restarted from scratch or failed outright with something like "There is already an open DataReader...".

This now only short-circuits to `null` when the source is a known `IReadOnlyCollection<T>`, checked via `Count` as @mgravell suggested in the issue thread. Everything else flows straight through untouched, so it's enumerated exactly once, by whoever actually executes the command.

Added three tests: one mirrors the original repro end-to-end (needs SQL Server to run), and two run offline against `SqlDataRecordListTVPParameter<T>.Set` directly, checking that a non-collection source is never touched and a known-empty collection still nulls out.

Fixes #2064
