### PR TITLE
Preserve Size set by type handlers for string parameters

### DIFF
--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -2852,21 +2852,21 @@ namespace Dapper
                 else
                 {
                     il.EmitCall(OpCodes.Callvirt, typeof(IDataParameter).GetProperty(nameof(IDataParameter.Value))!.GetSetMethod()!, null);// stack is now [parameters] [[parameters]] [parameter]
-                }
 
-                if (prop.PropertyType == typeof(string))
-                {
-                    var endOfSize = il.DefineLabel();
-                    var sizeLocal = GetSizeLocal();
-                    // don't set if 0
-                    il.Emit(OpCodes.Ldloc, sizeLocal); // [parameters] [[parameters]] [parameter] [size]
-                    il.Emit(OpCodes.Brfalse_S, endOfSize); // [parameters] [[parameters]] [parameter]
+                    if (prop.PropertyType == typeof(string))
+                    {
+                        var endOfSize = il.DefineLabel();
+                        var sizeLocal = GetSizeLocal();
+                        // don't set if 0
+                        il.Emit(OpCodes.Ldloc, sizeLocal); // [parameters] [[parameters]] [parameter] [size]
+                        il.Emit(OpCodes.Brfalse_S, endOfSize); // [parameters] [[parameters]] [parameter]
 
-                    il.Emit(OpCodes.Dup);// stack is now [parameters] [[parameters]] [parameter] [parameter]
-                    il.Emit(OpCodes.Ldloc, sizeLocal); // stack is now [parameters] [[parameters]] [parameter] [parameter] [size]
-                    il.EmitCall(OpCodes.Callvirt, typeof(IDbDataParameter).GetProperty(nameof(IDbDataParameter.Size))!.GetSetMethod()!, null); // stack is now [parameters] [[parameters]] [parameter]
+                        il.Emit(OpCodes.Dup);// stack is now [parameters] [[parameters]] [parameter] [parameter]
+                        il.Emit(OpCodes.Ldloc, sizeLocal); // stack is now [parameters] [[parameters]] [parameter] [parameter] [size]
+                        il.EmitCall(OpCodes.Callvirt, typeof(IDbDataParameter).GetProperty(nameof(IDbDataParameter.Size))!.GetSetMethod()!, null); // stack is now [parameters] [[parameters]] [parameter]
 
-                    il.MarkLabel(endOfSize);
+                        il.MarkLabel(endOfSize);
+                    }
                 }
                 if (checkForDuplicates)
                 {

--- a/tests/Dapper.Tests/Providers/SqliteTests.cs
+++ b/tests/Dapper.Tests/Providers/SqliteTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Data.Sqlite;
 using System;
+using System.Data;
 using System.Data.Common;
 using System.Linq;
 using System.Threading;
@@ -63,6 +64,46 @@ namespace Dapper.Tests
             Assert.Equal(42, row.Id);
             row = connection.QueryFirst<HazNameId>("select 42 as Id");
             Assert.Equal(42, row.Id);
+        }
+
+        [FactSqlite]
+        public void TypeHandlerSetValue_StringParameterSizeIsNotOverwritten_Issue2141()
+        {
+            using var connection = GetSQLiteConnection();
+
+            SqlMapper.ResetTypeHandlers();
+            SqlMapper.RemoveTypeMap(typeof(string));
+            var handler = new SizedStringTypeHandler();
+            SqlMapper.AddTypeHandler(handler);
+            try
+            {
+                // anonymous object parameters take the IL generator path, where the
+                // generated code used to overwrite the Size set by the handler
+                connection.Execute("select @p", new { p = "abc" });
+
+                Assert.NotNull(handler.LastParameter);
+                Assert.Equal(SizedStringTypeHandler.ExpectedSize, handler.LastParameter.Size);
+            }
+            finally
+            {
+                SqlMapper.ResetTypeHandlers();
+                SqlMapper.AddTypeMap(typeof(string), DbType.String);
+            }
+        }
+
+        private sealed class SizedStringTypeHandler : SqlMapper.TypeHandler<string>
+        {
+            public const int ExpectedSize = 12345;
+            public IDbDataParameter? LastParameter { get; private set; }
+
+            public override void SetValue(IDbDataParameter parameter, string? value)
+            {
+                parameter.Value = value;
+                parameter.Size = ExpectedSize;
+                LastParameter = parameter;
+            }
+
+            public override string Parse(object value) => (string)value;
         }
 
         [FactSqlite]


### PR DESCRIPTION
## Problem

When a `TypeHandler` is registered for `string` and a query is executed with an anonymous object parameter (the IL generator path in `CreateParamInfoGenerator`), the generated code invokes the handler's `SetValue` and then unconditionally sets the parameter's `Size` based on the string length heuristics (`DbString.DefaultLength` / `-1`), overwriting whatever `Size` the handler configured.

Reported in #2141. The `DynamicParameters` path already leaves the Size to the handler; only the IL path diverges.

## Reproduction

```csharp
SqlMapper.RemoveTypeMap(typeof(string));
SqlMapper.AddTypeHandler(new StringTypeHandler()); // sets parameter.Size = 12345

connection.Execute("select @p", new { p = "hello" });
// parameter.Size is 4000 on main, not 12345
```

## Fix

Move the string `Size` emission into the `handler is null` branch, so when a type handler is registered it fully owns parameter configuration, consistent with the `DynamicParameters` behavior.

## Testing

Added `TypeHandlerSetValue_StringParameterSizeIsNotOverwritten_Issue2141` to `SqliteTypeHandlerTests` (in-memory SQLite, no external database required). Verified it fails on current main and passes with this change; the existing `SqliteTypeHandlerTests` suite passes.

Fixes #2141
