### PR TITLE
Point docs links at dapperlib.dev

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,8 +7,8 @@
     <AssemblyOriginatorKeyFile>../Dapper.snk</AssemblyOriginatorKeyFile>
 
     <PackageId>$(AssemblyName)</PackageId>
-    <PackageReleaseNotes>https://dapperlib.github.io/Dapper/</PackageReleaseNotes>
-    <PackageProjectUrl>https://github.com/DapperLib/Dapper</PackageProjectUrl>
+    <PackageReleaseNotes>https://dapperlib.dev/</PackageReleaseNotes>
+    <PackageProjectUrl>https://dapperlib.dev/</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageIcon>Dapper.png</PackageIcon>
     <RepositoryType>git</RepositoryType>

--- a/Readme.md
+++ b/Readme.md
@@ -38,7 +38,7 @@ Sponsors
 Dapper was originally developed for and by Stack Overflow, but is F/OSS. Sponsorship is welcome and invited - see the sponsor link at the top of the page.
 A huge thanks to everyone (individuals or organisations) who have sponsored Dapper, but a massive thanks in particular to:
 
-- [Dapper Plus](https://dapper-plus.net/) is a major sponsor and is proud to contribute to the development of Dapper ([read more](https://dapperlib.github.io/Dapper/dapperplus))
+- [Dapper Plus](https://dapper-plus.net/) is a major sponsor and is proud to contribute to the development of Dapper ([read more](https://dapperlib.dev/dapperplus))
 - [AWS](https://github.com/aws) who sponsored Dapper from Oct 2023 via the [.NET on AWS Open Source Software Fund](https://github.com/aws/dotnet-foss)
 
 <a href="https://dapper-plus.net/"><img width="728" height="90" alt="Dapper Plus logo" src="https://raw.githubusercontent.com/DapperLib/Dapper/main/docs/dapper-sponsor.png" /></a>

--- a/docs/dapperplus.md
+++ b/docs/dapperplus.md
@@ -10,4 +10,4 @@ From 2024, Dapper Plus is now a major sponsor of Dapper, helping to secure ongoi
 This sponsorship does not impact the ownership, license, or any other particulars of how Dapper operates. The core Dapper libraries continue
 to be freely available and fully open source.
 
-<a href="https://dapper-plus.net/"><img width="728" height="90" alt="Dapper Plus logo" src="https://dapperlib.github.io/Dapper/dapper-sponsor.png" /></a>
+<a href="https://dapper-plus.net/"><img width="728" height="90" alt="Dapper Plus logo" src="https://dapperlib.dev/dapper-sponsor.png" /></a>

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -22,7 +22,7 @@ Sponsors
 Dapper was originally developed for and by Stack Overflow, but is F/OSS. Sponsorship is welcome and invited - see the sponsor link at the top of the page.
 A huge thanks to everyone (individuals or organisations) who have sponsored Dapper, but a massive thanks in particular to:
 
-- [Dapper Plus](https://dapper-plus.net/) is a major sponsor and is proud to contribute to the development of Dapper ([read more](https://dapperlib.github.io/Dapper/dapperplus))
+- [Dapper Plus](https://dapper-plus.net/) is a major sponsor and is proud to contribute to the development of Dapper ([read more](https://dapperlib.dev/dapperplus))
 - [AWS](https://github.com/aws) who sponsored Dapper from Oct 2023 via the [.NET on AWS Open Source Software Fund](https://github.com/aws/dotnet-foss)
 
 [![Dapper Plus logo](https://raw.githubusercontent.com/DapperLib/Dapper/main/docs/dapper-sponsor.png)](https://dapper-plus.net/)


### PR DESCRIPTION
The docs moved to https://dapperlib.dev; this updates the links that still pointed at `dapperlib.github.io/Dapper`.

Those URLs all still work — GitHub 301s them to the new domain with the path intact — so nothing is broken today. The reason to change them anyway is `PackageReleaseNotes`, which is baked into every package we publish and can't be corrected after the fact.

- `Directory.Build.props` — `PackageReleaseNotes`
- `Readme.md` and `docs/readme.md` — the Dapper Plus sponsor link (`docs/readme.md` is also the NuGet package readme, so it ships inside the package)
- `docs/dapperplus.md` — the sponsor image, which was linking back to the site it is itself served from

One change beyond a straight host swap: `PackageProjectUrl` now points at the docs site rather than the repo, matching DapperAOT. `RepositoryUrl` is untouched, so the source location is still published.

All four new URLs return 200, and the image still serves as `image/png`.