### PR TITLE
Point PackageReleaseNotes at GitHub Releases

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
     <AssemblyOriginatorKeyFile>../Dapper.snk</AssemblyOriginatorKeyFile>
 
     <PackageId>$(AssemblyName)</PackageId>
-    <PackageReleaseNotes>https://dapperlib.dev/</PackageReleaseNotes>
+    <PackageReleaseNotes>https://github.com/DapperLib/Dapper/releases</PackageReleaseNotes>
     <PackageProjectUrl>https://dapperlib.dev/</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageIcon>Dapper.png</PackageIcon>


### PR DESCRIPTION
`PackageReleaseNotes` pointed at the docs root. Release note tracking moved to GitHub Releases some time ago — `docs/index.md` says exactly that, and keeps only an archive below it with no new entries — so anyone following the link from NuGet landed on a page telling them to go somewhere else.

This points it straight at https://github.com/DapperLib/Dapper/releases.

Deliberately not doing the same in Dapper.Contrib: that repo has no GitHub releases at all and its `docs/index.md` is still where its notes are written, so its link is already correct.