### PR TITLE
DynamicParameters.AddParameters(IDbCommand): identity-free self-apply

### DIFF
--- a/Dapper/DynamicParameters.cs
+++ b/Dapper/DynamicParameters.cs
@@ -148,6 +148,20 @@ namespace Dapper
         }
 
         /// <summary>
+        /// Add all the parameters needed to the command just before it executes, using the
+        /// command's own text and type for any query-specific handling (literal tokens, etc);
+        /// this allows external tooling (for example build-time code generators) to apply a
+        /// parameter bag without constructing an <see cref="SqlMapper.Identity"/>
+        /// </summary>
+        /// <param name="command">The raw command prior to execution</param>
+        public void AddParameters(IDbCommand command)
+        {
+            if (command is null) throw new ArgumentNullException(nameof(command));
+            AddParameters(command, new SqlMapper.Identity(command.CommandText, command.CommandType,
+                command.Connection!, null, GetType()));
+        }
+
+        /// <summary>
         /// If true, the command-text is inspected and only values that are clearly used are included on the connection
         /// </summary>
         public bool RemoveUnused { get; set; }

--- a/Dapper/DynamicParameters.cs
+++ b/Dapper/DynamicParameters.cs
@@ -157,8 +157,10 @@ namespace Dapper
         public void AddParameters(IDbCommand command)
         {
             if (command is null) throw new ArgumentNullException(nameof(command));
-            AddParameters(command, new SqlMapper.Identity(command.CommandText, command.CommandType,
-                command.Connection!, null, GetType()));
+            // dispatch via the interface so that a subclass which hides AddParameters and
+            // re-implements IDynamicParameters (an established extension pattern) still runs
+            ((SqlMapper.IDynamicParameters)this).AddParameters(command, new SqlMapper.Identity(
+                command.CommandText, command.CommandType, command.Connection!, null, GetType()));
         }
 
         /// <summary>

--- a/Dapper/PublicAPI.Unshipped.txt
+++ b/Dapper/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
 ﻿#nullable enable
 static Dapper.SqlMapper.Settings.PreferTypeHandlersForEnums.get -> bool
 static Dapper.SqlMapper.Settings.PreferTypeHandlersForEnums.set -> void
+Dapper.DynamicParameters.AddParameters(System.Data.IDbCommand! command) -> void

--- a/tests/Dapper.Tests/ParameterTests.cs
+++ b/tests/Dapper.Tests/ParameterTests.cs
@@ -952,6 +952,32 @@ namespace Dapper.Tests
         }
 
         [Fact]
+        public void AddParameters_Command_DispatchesViaInterface()
+        {
+            // a subclass that hides AddParameters and re-implements IDynamicParameters
+            // (the DynamicParameterWithIntTVP pattern) must still get its version called
+            using var connection = GetClosedConnection();
+            using var command = connection.CreateCommand();
+            command.CommandText = "select @a";
+
+            var args = new HidingBag();
+            args.Add("a", 1);
+            args.AddParameters(command);
+
+            Assert.True(args.CustomRan);
+        }
+
+        private class HidingBag : DynamicParameters, SqlMapper.IDynamicParameters
+        {
+            public bool CustomRan { get; private set; }
+            public new void AddParameters(IDbCommand command, SqlMapper.Identity identity)
+            {
+                base.AddParameters(command, identity);
+                CustomRan = true;
+            }
+        }
+
+        [Fact]
         public void TestAppendingAnonClasses()
         {
             var p = new DynamicParameters();

--- a/tests/Dapper.Tests/ParameterTests.cs
+++ b/tests/Dapper.Tests/ParameterTests.cs
@@ -929,6 +929,29 @@ namespace Dapper.Tests
         }
 
         [Fact]
+        public void AddParameters_Command_AppliesBagAndLiterals()
+        {
+            // the identity-free overload: external tooling (e.g. build-time code generators)
+            // can apply a bag using the command's own text for query-specific handling
+            using var connection = GetClosedConnection();
+            using var command = connection.CreateCommand();
+            command.CommandText = "select @a + {=b}";
+
+            var args = new DynamicParameters();
+            args.Add("a", 1);
+            args.Add("b", 2);
+            args.AddParameters(command);
+
+            Assert.Equal("select @a + 2", command.CommandText); // literal replaced
+            // (note the literal member is still attached as a parameter too - unused, but
+            // that matches what the bag does under vanilla execution)
+            var p = Assert.IsAssignableFrom<IDbDataParameter>(command.Parameters[0]);
+            Assert.Equal("a", p.ParameterName);
+            Assert.Equal(1, p.Value);
+            Assert.Equal(2, command.Parameters.Count);
+        }
+
+        [Fact]
         public void TestAppendingAnonClasses()
         {
             var p = new DynamicParameters();


### PR DESCRIPTION
The full bag protocol — per-parameter `DbType`/direction/size/precision/scale, templates, literal replacement, `RemoveUnused` — already lives in `AddParameters(command, identity)`, but the identity requirement makes it uncallable from outside: `Identity`'s constructor is internal, and `identity.Sql` is consumed on the first line. This overload builds the identity from the command's own text and type (which is what `identity.Sql` is in practice), letting external tooling apply a parameter bag without reimplementing the protocol.

The immediate consumer is Dapper.AOT: its generated command factories can now support `DynamicParameters` arguments by delegating to the bag itself — which gives exact vanilla behavior for the whole surface (including `Get<T>` output reads and `IParameterCallbacks`) because it *is* the vanilla implementation. The generator probes for this symbol, so it activates only when the referenced Dapper has it; no coordination needed on release timing.

Test covers the bag + literal-replacement composition against a closed connection (no database needed). API registered in `PublicAPI.Unshipped.txt`.